### PR TITLE
v3.8.a feat: unify shared shell across home, game, and quiz and remove committed JetBrains project files

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml

--- a/.idea/ebu5315-interactive-media-design-and-production-2025-2026-25-26_ebu5315_g19.iml
+++ b/.idea/ebu5315-interactive-media-design-and-production-2025-2026-25-26_ebu5315_g19.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="PYTHON_MODULE" version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,6 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <settings>
-    <option name="USE_PROJECT_PROFILE" value="false" />
-    <version value="1.0" />
-  </settings>
-</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Black">
-    <option name="sdkName" value="Python 3.13" />
-  </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.13" project-jdk-type="Python SDK" />
-</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/ebu5315-interactive-media-design-and-production-2025-2026-25-26_ebu5315_g19.iml" filepath="$PROJECT_DIR$/.idea/ebu5315-interactive-media-design-and-production-2025-2026-25-26_ebu5315_g19.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-  </component>
-</project>

--- a/css/game.css
+++ b/css/game.css
@@ -1,12 +1,4 @@
 :root {
-    --primary-blue: #3a7bd5;
-    --primary-blue-deep: #284f86;
-    --bg-color: #f4f7fc;
-    --text-color: #1e2b3c;
-    --muted-text: #5f7088;
-    --card-bg: #ffffff;
-    --border-color: #d0dae8;
-    --shadow: 0 12px 28px rgba(18, 36, 67, 0.08);
     --stage-glow: linear-gradient(135deg, rgba(58, 123, 213, 0.16), rgba(47, 181, 163, 0.08));
     --board-bg: #fdfefe;
     --board-grid: rgba(58, 123, 213, 0.12);
@@ -14,7 +6,6 @@
     --radius-color: #3a7bd5;
     --tangent-color: #ef6b6b;
     --arc-color: #f3b957;
-    --secondary-line: #5fc1b3;
     --point-fill: #3a7bd5;
     --point-fixed: #ffffff;
     --point-stroke: #244f86;
@@ -24,16 +15,9 @@
     --info-text: #244f86;
     --error-bg: rgba(231, 76, 60, 0.14);
     --error-text: #a53a2f;
-    --font-size-base: 16px;
 }
 
 [data-theme="dark"] {
-    --bg-color: #121826;
-    --text-color: #e3e9f2;
-    --muted-text: #a8b7cc;
-    --card-bg: #1f2a3c;
-    --border-color: #33435d;
-    --shadow: 0 16px 36px rgba(0, 0, 0, 0.28);
     --stage-glow: linear-gradient(135deg, rgba(90, 156, 255, 0.22), rgba(47, 181, 163, 0.12));
     --board-bg: #162031;
     --board-grid: rgba(125, 176, 255, 0.14);
@@ -41,7 +25,6 @@
     --radius-color: #7db0ff;
     --tangent-color: #ff8b7d;
     --arc-color: #f4c86d;
-    --secondary-line: #72d9c9;
     --point-fill: #7db0ff;
     --point-fixed: #1f2a3c;
     --point-stroke: #dce7f8;
@@ -51,131 +34,6 @@
     --info-text: #bcd7ff;
     --error-bg: rgba(255, 139, 125, 0.16);
     --error-text: #ffc1ba;
-}
-
-* {
-    box-sizing: border-box;
-}
-
-body {
-    margin: 0;
-    background: var(--bg-color);
-    color: var(--text-color);
-    font-size: var(--font-size-base);
-    font-family: 'Segoe UI', Tahoma, sans-serif;
-    line-height: 1.6;
-    transition: background 0.25s ease, color 0.25s ease;
-}
-
-.container {
-    width: 100%;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 20px;
-}
-
-#accessibility-bar {
-    background: var(--card-bg);
-    border-bottom: 1px solid var(--border-color);
-    padding: 8px 0;
-}
-
-#accessibility-bar .container {
-    display: flex;
-    justify-content: flex-end;
-    gap: 10px;
-    flex-wrap: wrap;
-}
-
-#accessibility-bar button {
-    background: transparent;
-    border: 1px solid var(--border-color);
-    color: var(--text-color);
-    padding: 6px 12px;
-    border-radius: 999px;
-    cursor: pointer;
-    font-weight: 600;
-    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-}
-
-#accessibility-bar button:hover {
-    background: var(--primary-blue);
-    color: #ffffff;
-    border-color: var(--primary-blue);
-}
-
-header {
-    background: var(--card-bg);
-    border-bottom: 1px solid var(--border-color);
-    box-shadow: var(--shadow);
-    padding: 18px 0;
-}
-
-.header-content {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 20px;
-    flex-wrap: wrap;
-}
-
-.logo {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    color: var(--text-color);
-    text-decoration: none;
-    font-size: 1.75rem;
-    font-weight: 700;
-}
-
-.logo-icon {
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--primary-blue);
-    color: #ffffff;
-    font-size: 1.5rem;
-}
-
-.nav-links {
-    list-style: none;
-    display: flex;
-    gap: 24px;
-    margin: 0;
-    padding: 0;
-}
-
-.nav-links a {
-    color: var(--text-color);
-    text-decoration: none;
-    font-weight: 600;
-    padding-bottom: 6px;
-    border-bottom: 2px solid transparent;
-}
-
-.nav-links a.active,
-.nav-links a:hover {
-    color: var(--primary-blue);
-    border-bottom-color: var(--primary-blue);
-}
-
-.breadcrumb {
-    margin: 20px 0 8px;
-    color: var(--muted-text);
-    font-size: 0.95rem;
-}
-
-.breadcrumb a {
-    color: var(--primary-blue);
-    text-decoration: none;
-}
-
-main.container {
-    padding-bottom: 72px;
 }
 
 .game-layout {
@@ -296,16 +154,10 @@ main.container {
 }
 
 .mission-card,
-.target-card {
-    padding: 24px;
-}
-
-.panel-card {
-    padding: 24px;
-}
-
+.target-card,
+.panel-card,
 .hud-chip {
-    padding: 16px 18px;
+    padding: 24px;
 }
 
 .mission-card h3,
@@ -409,12 +261,12 @@ main.container {
 }
 
 .hud-chip {
-    padding: 16px 18px;
     display: grid;
     grid-template-columns: minmax(92px, 160px) minmax(0, 1fr);
     gap: 16px;
     align-items: center;
     min-height: 72px;
+    padding: 16px 18px;
 }
 
 .hud-chip span {
@@ -432,11 +284,8 @@ main.container {
     text-align: left;
     line-height: 1.45;
     min-width: 0;
-    overflow: visible;
     overflow-wrap: anywhere;
     display: block;
-    min-height: 0;
-    max-height: none;
 }
 
 .hud-chip[data-field],
@@ -742,17 +591,10 @@ main.container {
     border: 1px solid transparent;
     border-radius: 999px;
     padding: 12px 16px;
-    font-size: 1rem;
+    font: inherit;
     font-weight: 700;
     cursor: pointer;
     transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
-}
-
-.control-card button,
-.arena-actions button,
-.mode-btn,
-#ai-chat-widget input {
-    font-family: inherit;
 }
 
 .control-card button,
@@ -866,31 +708,12 @@ main.container {
     padding: 10px 12px;
     background: var(--bg-color);
     color: var(--text-color);
+    font: inherit;
 }
 
 #ai-chat-widget input:focus {
     outline: 2px solid rgba(58, 123, 213, 0.2);
     border-color: var(--primary-blue);
-}
-
-footer {
-    background: var(--card-bg);
-    border-top: 1px solid var(--border-color);
-    padding: 28px 0;
-}
-
-.footer-content,
-.footer-links {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 16px;
-    flex-wrap: wrap;
-}
-
-.footer-links a {
-    color: var(--text-color);
-    text-decoration: none;
 }
 
 @media (max-width: 980px) {
@@ -910,8 +733,7 @@ footer {
 
     .target-card,
     .arena-hud,
-    .arena-actions,
-    .footer-content {
+    .arena-actions {
         margin-top: 14px;
     }
 
@@ -922,10 +744,6 @@ footer {
 }
 
 @media (max-width: 720px) {
-    .container {
-        padding: 0 16px;
-    }
-
     .prototype-stage,
     .panel-card {
         padding: 22px;
@@ -967,9 +785,6 @@ footer {
         grid-template-columns: 1fr;
         gap: 8px;
         align-items: start;
-    }
-
-    .hud-chip {
         padding: 16px;
     }
 

--- a/css/global.css
+++ b/css/global.css
@@ -1,0 +1,413 @@
+:root {
+    --primary-color: #3a7bd5;
+    --primary-hover: #2b5fa8;
+    --primary-blue: #3a7bd5;
+    --primary-blue-deep: #284f86;
+    --secondary-line: #5fc1b3;
+    --bg-color: #f4f7fc;
+    --text-color: #1e2b3c;
+    --muted-text: #5f7088;
+    --card-bg: #ffffff;
+    --header-bg: #ffffff;
+    --footer-bg: #ffffff;
+    --footer-text: #1e2b3c;
+    --border-color: #d0dae8;
+    --secondary-bg: #e9eef4;
+    --shadow: 0 12px 28px rgba(18, 36, 67, 0.08);
+    --font-size-base: 16px;
+}
+
+[data-theme="dark"] {
+    --primary-color: #7db0ff;
+    --primary-hover: #9bc0ff;
+    --primary-blue: #7db0ff;
+    --primary-blue-deep: #d8e6ff;
+    --bg-color: #121826;
+    --text-color: #e3e9f2;
+    --muted-text: #a8b7cc;
+    --card-bg: #1f2a3c;
+    --header-bg: #1f2a3c;
+    --footer-bg: #1f2a3c;
+    --footer-text: #e3e9f2;
+    --border-color: #33435d;
+    --secondary-bg: #253246;
+    --shadow: 0 16px 36px rgba(0, 0, 0, 0.28);
+}
+
+[data-a11y="high-contrast"] {
+    --primary-color: #ffff00;
+    --primary-hover: #ffffff;
+    --primary-blue: #ffff00;
+    --primary-blue-deep: #ffffff;
+    --bg-color: #000000;
+    --text-color: #ffffff;
+    --muted-text: #f5f58a;
+    --card-bg: #000000;
+    --header-bg: #000000;
+    --footer-bg: #000000;
+    --footer-text: #ffffff;
+    --border-color: #ffff00;
+    --secondary-bg: #000000;
+    --shadow: none;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+[hidden] {
+    display: none !important;
+}
+
+.modal-overlay[hidden] {
+    display: none !important;
+    pointer-events: none !important;
+}
+
+html {
+    font-size: 100%;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-color);
+    color: var(--text-color);
+    font-size: var(--font-size-base);
+    font-family: "Segoe UI", Tahoma, sans-serif;
+    line-height: 1.6;
+    transition: background 0.25s ease, color 0.25s ease;
+}
+
+main {
+    flex: 1;
+}
+
+main.container {
+    padding-bottom: 72px;
+}
+
+.container {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+#accessibility-bar {
+    background: var(--card-bg);
+    border-bottom: 1px solid var(--border-color);
+    padding: 8px 0;
+}
+
+#accessibility-bar .container {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+#accessibility-bar button,
+.nav-toggle,
+.modal-close-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    padding: 8px 14px;
+    background: transparent;
+    color: var(--text-color);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+#accessibility-bar button:hover,
+#accessibility-bar button:focus-visible,
+.nav-toggle:hover,
+.nav-toggle:focus-visible,
+.modal-close-btn:hover,
+.modal-close-btn:focus-visible {
+    background: var(--primary-blue);
+    color: #ffffff;
+    border-color: var(--primary-blue);
+    transform: translateY(-1px);
+}
+
+header {
+    background: var(--header-bg);
+    border-bottom: 1px solid var(--border-color);
+    box-shadow: var(--shadow);
+    padding: 18px 0;
+    margin-bottom: 0;
+}
+
+.header-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    flex-wrap: wrap;
+}
+
+.logo {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--text-color);
+    text-decoration: none;
+    font-size: 1.75rem;
+    font-weight: 700;
+}
+
+.logo-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--primary-blue);
+    color: #ffffff;
+    font-size: 1.5rem;
+}
+
+.nav-toggle {
+    display: none;
+}
+
+.nav-toggle-icon {
+    font-size: 1rem;
+    line-height: 1;
+}
+
+.site-nav {
+    display: flex;
+    align-items: center;
+}
+
+.nav-links {
+    list-style: none;
+    display: flex;
+    gap: 24px;
+    margin: 0;
+    padding: 0;
+}
+
+.nav-links a {
+    display: inline-flex;
+    align-items: center;
+    min-height: 40px;
+    color: var(--text-color);
+    text-decoration: none;
+    font-weight: 600;
+    padding-bottom: 6px;
+    border-bottom: 2px solid transparent;
+    transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.nav-links a.active,
+.nav-links a:hover,
+.nav-links a:focus-visible {
+    color: var(--primary-blue);
+    border-bottom-color: var(--primary-blue);
+}
+
+.breadcrumb {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 20px 0 12px;
+    color: var(--muted-text);
+    font-size: 0.95rem;
+}
+
+.breadcrumb a {
+    color: var(--primary-blue);
+    text-decoration: none;
+}
+
+.breadcrumb-separator {
+    color: var(--muted-text);
+}
+
+footer {
+    margin-top: auto;
+    background: var(--footer-bg);
+    border-top: 1px solid var(--border-color);
+    padding: 28px 0;
+}
+
+.footer-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.footer-links {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.footer-links a {
+    color: var(--footer-text);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.footer-links a:hover,
+.footer-links a:focus-visible {
+    color: var(--primary-blue);
+}
+
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: rgba(0, 0, 0, 0.72);
+    backdrop-filter: blur(6px);
+    z-index: 4000;
+}
+
+.modal-content {
+    position: relative;
+    width: min(560px, 100%);
+    background: var(--card-bg);
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
+    border-radius: 24px;
+    box-shadow: var(--shadow);
+    padding: 28px;
+}
+
+.privacy-box {
+    text-align: left;
+}
+
+.privacy-box h2,
+.privacy-box h3 {
+    color: var(--primary-blue);
+    margin-top: 0;
+}
+
+.privacy-box ul {
+    padding-left: 20px;
+    margin: 14px 0;
+}
+
+.privacy-box li {
+    margin-bottom: 10px;
+}
+
+.preference-note {
+    margin-top: 18px;
+    padding: 14px 16px;
+    border-radius: 16px;
+    background: var(--secondary-bg);
+    border: 1px solid var(--border-color);
+}
+
+.close-modal {
+    position: absolute;
+    top: 14px;
+    right: 18px;
+    border: none;
+    background: transparent;
+    color: var(--muted-text);
+    font-size: 1.6rem;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.close-modal:hover,
+.close-modal:focus-visible {
+    color: var(--primary-blue);
+}
+
+.modal-close-btn {
+    margin-top: 18px;
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@media (max-width: 760px) {
+    .container {
+        padding: 0 16px;
+    }
+
+    .header-content {
+        align-items: flex-start;
+    }
+
+    .nav-toggle {
+        display: inline-flex;
+    }
+
+    .site-nav {
+        display: none;
+        width: 100%;
+    }
+
+    .site-nav.is-open {
+        display: block;
+    }
+
+    .nav-links {
+        flex-direction: column;
+        width: 100%;
+        gap: 8px;
+        padding: 12px;
+        border: 1px solid var(--border-color);
+        border-radius: 20px;
+        background: var(--card-bg);
+        box-shadow: var(--shadow);
+    }
+
+    .nav-links a {
+        width: 100%;
+        padding: 10px 12px;
+        border-bottom: none;
+        border-radius: 12px;
+    }
+
+    .nav-links a.active,
+    .nav-links a:hover,
+    .nav-links a:focus-visible {
+        border-bottom-color: transparent;
+        background: rgba(58, 123, 213, 0.12);
+    }
+
+    .footer-content,
+    .footer-links {
+        width: 100%;
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .breadcrumb {
+        margin-top: 16px;
+    }
+}

--- a/css/home.css
+++ b/css/home.css
@@ -1,947 +1,604 @@
-/* 基础变量 */
-:root {
-    --primary-blue: #007bff;
-    --bg-color: #ffffff;
-    --text-color: #333333;
-    --card-bg: #f8f9fa;
-    --font-size-base: 16px;
+#hero {
+    padding: 28px 0 24px;
+    text-align: center;
 }
 
-/* 暗黑模式 */
-[data-theme="dark"] {
-    --bg-color: #1a1a1a;
-    --text-color: #f0f0f0;
-    --card-bg: #2d2d2d;
+#hero h1 {
+    margin: 0;
+    font-size: clamp(2.6rem, 6vw, 4.8rem);
+    line-height: 1.08;
+    letter-spacing: -0.03em;
 }
 
-/* V2: 高对比度模式 (A11y) */
-[data-a11y="high-contrast"] {
-    --primary-blue: #ffff00 !important;
-    --bg-color: #000000 !important;
-    --text-color: #ffff00 !important;
-    --card-bg: #1a1a1a !important;
+.highlight {
+    color: var(--primary-blue);
 }
 
-body {
-    background-color: var(--bg-color);
-    color: var(--text-color);
-    font-size: var(--font-size-base);
-    font-family: 'Segoe UI', Tahoma, sans-serif;
-    margin: 0; transition: all 0.3s ease;
+.usp {
+    max-width: 680px;
+    margin: 18px auto 0;
+    font-size: 1.1rem;
+    color: var(--muted-text);
 }
 
-.container { max-width: 1100px; margin: 0 auto; padding: 0 20px; }
-
-/* 顶部工具栏 */
-#accessibility-bar { background: #333; padding: 5px 0; text-align: right; }
-#accessibility-bar button { background: #444; color: white; border: none; padding: 5px 10px; cursor: pointer; margin-left: 5px; border-radius: 4px; }
-
-header { background: var(--card-bg); padding: 1rem 0; border-bottom: 1px solid #ddd; }
-.header-content { display: flex; justify-content: space-between; align-items: center; }
-.logo { display: flex; align-items: center; text-decoration: none; font-weight: bold; color: var(--primary-blue); font-size: 1.5rem; }
-.logo-icon { width: 35px; height: 35px; border: 2px solid var(--primary-blue); border-radius: 50%; display: flex; align-items: center; justify-content: center; margin-right: 10px; }
-.nav-links { list-style: none; display: flex; gap: 20px; }
-.nav-links a { text-decoration: none; color: var(--text-color); }
-
-/* V2: SVG 动画效果 */
 .video-container {
-    background: radial-gradient(circle, var(--card-bg) 0%, rgba(0,123,255,0.05) 100%);
-    border-radius: 15px; height: 350px; display: flex; align-items: center; justify-content: center; margin-top: 30px; border: 2px solid var(--primary-blue);
+    margin-top: 32px;
+    padding: 28px;
+    border: 1px solid var(--border-color);
+    border-radius: 32px;
+    background: radial-gradient(circle at top, rgba(58, 123, 213, 0.12), transparent 58%), var(--card-bg);
+    box-shadow: var(--shadow);
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
-#hero-svg { animation: hero-float 4s ease-in-out infinite; }
+
+#hero-svg {
+    width: min(100%, 540px);
+    height: auto;
+    animation: hero-float 4s ease-in-out infinite;
+}
+
 @keyframes hero-float {
-    0%, 100% { transform: translateY(0); }
-    50% { transform: translateY(-15px); }
+    0%,
+    100% {
+        transform: translateY(0);
+    }
+
+    50% {
+        transform: translateY(-14px);
+    }
 }
 
-/* 规则卡片 */
-#rules { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 25px; margin-top: 50px; }
-.rule-card { background: var(--card-bg); padding: 30px; border-radius: 12px; text-align: center; box-shadow: 0 4px 10px rgba(0,0,0,0.05); }
+#learning-hub,
+#culture,
+.ads-section {
+    margin-top: 56px;
+}
 
-/* V2: 聊天悬浮按钮 */
+.section-title {
+    margin: 0 0 28px;
+    font-size: clamp(2rem, 4vw, 3rem);
+    text-align: center;
+    color: var(--text-color);
+}
+
+.theorem-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 24px;
+}
+
+.theorem-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+    padding: 30px 28px 26px;
+    border: 1px solid rgba(58, 123, 213, 0.14);
+    border-radius: 28px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(244, 247, 252, 0.98));
+    box-shadow: var(--shadow);
+    cursor: pointer;
+    transition: transform 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease;
+}
+
+.theorem-card:hover {
+    transform: translateY(-6px);
+    border-color: rgba(58, 123, 213, 0.38);
+    box-shadow: 0 18px 36px rgba(18, 36, 67, 0.14);
+}
+
+[data-theme="dark"] .theorem-card {
+    background: linear-gradient(180deg, rgba(31, 42, 60, 0.96), rgba(23, 33, 48, 0.98));
+    border-color: rgba(125, 176, 255, 0.16);
+}
+
+.badge {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    padding: 5px 10px;
+    border-radius: 999px;
+    background: rgba(58, 123, 213, 0.12);
+    color: var(--primary-blue);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.rule-icon {
+    font-size: 2rem;
+    line-height: 1;
+    margin-bottom: 16px;
+}
+
+.theorem-card h3 {
+    margin: 0 0 10px;
+    color: var(--primary-blue);
+    font-size: 1.35rem;
+}
+
+.theorem-card p {
+    margin: 0;
+    color: var(--muted-text);
+    line-height: 1.7;
+}
+
+.learn-more {
+    margin-top: auto;
+    align-self: flex-start;
+    padding: 10px 18px;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--text-color);
+    font: inherit;
+    font-weight: 700;
+    pointer-events: none;
+}
+
+#culture {
+    padding: 36px;
+    border: 1px solid var(--border-color);
+    border-radius: 32px;
+    background: var(--card-bg);
+    box-shadow: var(--shadow);
+}
+
+.culture-header {
+    margin-bottom: 22px;
+}
+
+.culture-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px;
+    border-radius: 999px;
+    background: rgba(58, 123, 213, 0.1);
+    color: var(--primary-blue);
+    font-weight: 700;
+}
+
+.culture-cards-container {
+    display: grid;
+    gap: 24px;
+}
+
+.bio-card {
+    display: grid;
+    grid-template-columns: 260px minmax(0, 1fr);
+    border: 1px solid var(--border-color);
+    border-radius: 28px;
+    overflow: hidden;
+    background: var(--card-bg);
+    box-shadow: 0 14px 28px rgba(18, 36, 67, 0.08);
+}
+
+.bio-image {
+    min-height: 260px;
+    background: linear-gradient(160deg, rgba(58, 123, 213, 0.08), rgba(95, 193, 179, 0.12));
+}
+
+.bio-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.bio-info {
+    padding: 28px;
+}
+
+.bio-name {
+    margin: 0 0 14px;
+    color: var(--primary-blue);
+    font-size: 1.85rem;
+}
+
+.bio-meta p,
+.bio-intro p {
+    margin: 8px 0;
+    color: var(--muted-text);
+}
+
+.bio-intro {
+    margin-top: 18px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border-color);
+}
+
+.ads-section {
+    display: grid;
+    gap: 20px;
+    margin-bottom: 24px;
+}
+
+.external-ad {
+    position: relative;
+    padding: 20px;
+    border: 1px dashed var(--border-color);
+    border-radius: 24px;
+    background: var(--secondary-bg);
+}
+
+.ad-tag {
+    position: absolute;
+    top: 16px;
+    right: 18px;
+    color: var(--muted-text);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.ad-content {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.ad-content img {
+    width: 48px;
+    height: 48px;
+    flex-shrink: 0;
+}
+
+.ad-content p {
+    margin: 0;
+}
+
+.ad-content a {
+    color: var(--primary-blue);
+}
+
+.pro-banner {
+    padding: 38px;
+    border-radius: 28px;
+    background: linear-gradient(135deg, var(--primary-blue), var(--primary-blue-deep));
+    color: #ffffff;
+    text-align: center;
+    box-shadow: var(--shadow);
+}
+
+.pro-banner h3,
+.pro-banner p {
+    margin: 0;
+}
+
+.pro-banner p {
+    margin-top: 12px;
+    color: rgba(255, 255, 255, 0.88);
+}
+
+.pro-btn {
+    margin-top: 18px;
+    padding: 12px 22px;
+    border: none;
+    border-radius: 999px;
+    background: #ffd75f;
+    color: #24324a;
+    font: inherit;
+    font-weight: 800;
+    cursor: pointer;
+}
+
+#detail-view {
+    padding-top: 8px;
+    animation: fadeIn 0.35s ease;
+}
+
+#theorems-accordion-container {
+    display: grid;
+    gap: 16px;
+    max-width: 960px;
+    margin: 0 auto;
+}
+
+.detail-back-row {
+    margin-top: 24px;
+    display: flex;
+    justify-content: flex-start;
+}
+
+.control-btn,
+.detail-back-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 12px 18px;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--text-color);
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.accordion-item {
+    border: 1px solid var(--border-color);
+    border-radius: 24px;
+    overflow: hidden;
+    background: var(--card-bg);
+    box-shadow: var(--shadow);
+}
+
+.accordion-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 20px 24px;
+    cursor: pointer;
+    font-size: 1.15rem;
+    font-weight: 700;
+}
+
+.accordion-item.active .accordion-header {
+    background: rgba(58, 123, 213, 0.08);
+    color: var(--primary-blue);
+}
+
+.arrow-icon {
+    transition: transform 0.2s ease;
+}
+
+.accordion-item.active .arrow-icon {
+    transform: rotate(180deg);
+}
+
+.accordion-content {
+    display: none;
+    grid-template-columns: minmax(260px, 340px) minmax(0, 1fr);
+    gap: 24px;
+    padding: 0 24px 24px;
+}
+
+.accordion-item.active .accordion-content {
+    display: grid;
+}
+
+.demo-container {
+    min-height: 280px;
+    padding: 20px;
+    border: 1px solid var(--border-color);
+    border-radius: 20px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(233, 238, 244, 0.92));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+[data-theme="dark"] .demo-container {
+    background: linear-gradient(180deg, rgba(31, 42, 60, 0.92), rgba(23, 33, 48, 0.98));
+}
+
+.demo-container svg {
+    width: 100%;
+    max-width: 280px;
+    height: auto;
+}
+
+.info-container {
+    padding-top: 6px;
+}
+
+.info-container h3 {
+    margin: 0 0 12px;
+    color: var(--primary-blue);
+}
+
+.info-container p {
+    margin: 0;
+    color: var(--muted-text);
+    line-height: 1.7;
+}
+
+.prop-list-pro {
+    display: grid;
+    gap: 10px;
+    margin-top: 16px;
+}
+
+.property-item {
+    padding: 10px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 14px;
+    background: var(--secondary-bg);
+    color: var(--text-color);
+}
+
 #chat-toggle-btn {
-    position: fixed; bottom: 25px; right: 25px; width: 60px; height: 60px;
-    background: var(--primary-blue); border-radius: 50%; display: flex;
-    justify-content: center; align-items: center; font-size: 30px; cursor: pointer; z-index: 1000;
+    position: fixed;
+    right: 24px;
+    bottom: 24px;
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, var(--primary-blue), var(--primary-blue-deep));
+    color: #ffffff;
+    font-size: 1.75rem;
+    box-shadow: 0 18px 36px rgba(18, 36, 67, 0.22);
+    cursor: pointer;
+    z-index: 24;
 }
-
-/* --- 完整的 Version 4 AI 聊天框样式 (已整合深蓝配色与溢出修复) --- */
 
 #ai-chat-widget {
     position: fixed;
-    bottom: 95px;
-    right: 25px;
-    width: 300px;
+    right: 24px;
+    bottom: 96px;
+    width: min(340px, calc(100vw - 32px));
+    border: 1px solid var(--border-color);
+    border-radius: 22px;
     background: var(--card-bg);
-    border: 2px solid #0056b3; /* 深蓝色边框 */
-    border-radius: 15px;
-    overflow: hidden; /* 关键：确保里面的内容不刺出圆角 */
-    z-index: 1000;
-    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow);
+    overflow: hidden;
+    z-index: 25;
+}
+
+#ai-chat-widget[hidden] {
+    display: none;
 }
 
 .chat-header {
-    background: #0056b3; /* 头部深蓝色 */
-    color: white;
-    padding: 12px;
-    font-weight: bold;
     display: flex;
-    justify-content: space-between;
     align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 14px 16px;
+    background: linear-gradient(135deg, var(--primary-blue), var(--primary-blue-deep));
+    color: #ffffff;
+    font-weight: 700;
+}
+
+.chat-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.chat-icon-btn {
+    width: 36px;
+    height: 36px;
+    border: 1px solid rgba(255, 255, 255, 0.34);
+    border-radius: 999px;
+    background: transparent;
+    color: #ffffff;
+    font: inherit;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .chat-body {
-    height: 200px;
+    max-height: 220px;
     overflow-y: auto;
-    padding: 10px;
-    color: var(--text-color);
-    background: var(--bg-color);
+    padding: 16px;
+}
+
+.chat-body p {
+    margin: 0 0 12px;
 }
 
 .chat-input {
-    background: var(--card-bg);
-    border-top: 1px solid rgba(0, 86, 179, 0.2); /* 顶部细分割线 */
+    padding: 14px 16px 16px;
+    border-top: 1px solid var(--border-color);
 }
 
 .chat-input input {
     width: 100%;
-    border: none;
-    padding: 12px 15px;
-    background: transparent;
+    padding: 11px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 14px;
+    background: var(--bg-color);
     color: var(--text-color);
-    font-size: 14px;
-    display: block;
-    box-sizing: border-box;
+    font: inherit;
 }
 
-/* 彻底解决点击时的黑框问题 */
 .chat-input input:focus {
-    outline: none; /* 移除默认黑框 */
-    background-color: rgba(0, 86, 179, 0.05); /* 聚焦时淡淡的蓝色背景 */
-}
-
-/* 暗黑模式同步 */
-[data-theme="dark"] #ai-chat-widget {
-    border-color: #007bff; /* 暗黑模式下用稍亮一点的蓝色，看得更清 */
-}
-
-/* V2: 确认弹窗样式 */
-#confirm-modal { position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 2000; display: flex; align-items: center; justify-content: center; }
-.modal-overlay { position: absolute; width: 100%; height: 100%; background: rgba(0,0,0,0.8); }
-.modal-content { position: relative; background: var(--card-bg); padding: 30px; border-radius: 15px; border: 2px solid var(--primary-blue); text-align: center; }
-.btn-danger { background: #ff4757; color: white; border: none; padding: 8px 20px; border-radius: 5px; cursor: pointer; margin-right: 10px; }
-
-footer { background: var(--card-bg); padding: 2rem 0; margin-top: 50px; border-top: 1px solid #ddd; }
-/* =========================================
-   Version 3 新增样式：学习中心与文化板块
-   ========================================= */
-
-/* 1. 标题渐变效果 - 增加视觉冲击力 (Creativity 项) */
-.section-title {
-    text-align: center;
-    font-size: 2.5rem;
-    margin-top: 60px;
-    margin-bottom: 30px;
-    background: linear-gradient(45deg, var(--primary-blue), #ff4757);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    font-weight: 800;
-}
-
-/* 2. 玻璃拟态卡片网格 (Marking Point: High Appeal) */
-.theorem-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 30px;
-    margin-top: 20px;
-}
-
-.theorem-card {
-    background: rgba(255, 255, 255, 0.6); /* 半透明背景 */
-    backdrop-filter: blur(12px);         /* 毛玻璃模糊 */
-    -webkit-backdrop-filter: blur(12px);
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    padding: 30px;
-    border-radius: 24px;
-    position: relative;
-    transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-    box-shadow: 0 8px 32px rgba(0,0,0,0.05);
-}
-
-/* 暗黑模式下的玻璃效果 */
-[data-theme="dark"] .theorem-card {
-    background: rgba(45, 45, 45, 0.6);
-    border-color: rgba(255, 255, 255, 0.1);
-    box-shadow: 0 8px 32px rgba(0,0,0,0.3);
-}
-
-.theorem-card:hover {
-    transform: translateY(-12px);
-    box-shadow: 0 20px 40px rgba(0, 123, 255, 0.2);
+    outline: none;
     border-color: var(--primary-blue);
+    box-shadow: 0 0 0 4px rgba(58, 123, 213, 0.16);
 }
 
-/* 难度标签 */
-.badge {
-    position: absolute;
-    top: 15px;
-    right: 15px;
-    background: var(--primary-blue);
-    color: white;
-    font-size: 11px;
-    padding: 4px 10px;
-    border-radius: 20px;
-    font-weight: bold;
-    text-transform: uppercase;
-}
-
-/* 3. 文化多样性板块 (Cultural Awareness - 2分) */
-#culture {
-    margin: 80px 0;
-    background: var(--card-bg);
-    border-radius: 40px;
-    padding: 50px;
-    border: 1px solid rgba(0,0,0,0.05);
-}
-
-.culture-flex {
+.modal-actions {
     display: flex;
-    align-items: center;
-    justify-content: space-around;
-    text-align: center;
-    gap: 30px;
-    flex-wrap: wrap; /* 适配移动端响应式 */
-}
-
-.culture-item {
-    flex: 1;
-    min-width: 250px;
-}
-
-.culture-item img {
-    width: 80px;
-    height: 80px;
-    margin-bottom: 20px;
-    filter: drop-shadow(0 5px 15px rgba(0,0,0,0.1));
-}
-
-.culture-divider {
-    font-weight: 900;
-    font-size: 32px;
-    color: #ff4757;
-    font-style: italic;
-}
-
-/* 4. 定理卡片中的按钮 */
-.learn-more {
-    background: transparent;
-    border: 2px solid var(--primary-blue);
-    color: var(--primary-blue);
-    padding: 8px 20px;
-    border-radius: 25px;
-    cursor: pointer;
+    justify-content: center;
+    gap: 12px;
+    flex-wrap: wrap;
     margin-top: 20px;
-    font-weight: bold;
-    transition: 0.3s;
 }
 
-.learn-more:hover {
-    background: var(--primary-blue);
-    color: white;
-    box-shadow: 0 5px 15px rgba(0, 123, 255, 0.3);
+.btn-danger {
+    padding: 10px 20px;
+    border: 1px solid #d95454;
+    border-radius: 999px;
+    background: #d95454;
+    color: #ffffff;
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
 }
-
-/* 广告位组合 */
-.ads-section { margin: 60px 0; display: flex; flex-direction: column; gap: 20px; }
-
-.external-ad {
-    background: #f1f3f5; border: 1px dashed #adb5bd;
-    padding: 15px; border-radius: 10px; position: relative;
-}
-[data-theme="dark"] .external-ad { background: #2b2b2b; }
-
-.ad-tag { position: absolute; top: 5px; right: 10px; font-size: 10px; color: #888; text-transform: uppercase; }
-.ad-content { display: flex; align-items: center; gap: 15px; }
-
-.pro-banner {
-    background: linear-gradient(135deg, #6610f2, var(--primary-blue));
-    color: white; padding: 40px; border-radius: 20px; text-align: center;
-}
-.pro-btn {
-    background: #ffc107; border: none; padding: 12px 30px;
-    border-radius: 30px; font-weight: bold; cursor: pointer; margin-top: 15px;
-}
-
-/* 详情视图样式 */
-#detail-view {
-    padding: 40px 0;
-    animation: fadeIn 0.5s ease;
-}
-
-.back-btn {
-    background: none; border: none; color: var(--primary-blue);
-    font-weight: bold; cursor: pointer; font-size: 1.1rem; margin-bottom: 20px;
-}
-
-.detail-header { display: flex; align-items: center; gap: 20px; margin-bottom: 30px; }
-
-.detail-content {
-    display: grid;
-    grid-template-columns: 1.5fr 1fr; /* 侧重左边的交互展示 */
-    gap: 40px;
-}
-
-/* 适配移动端 */
-@media (max-width: 768px) {
-    .detail-content { grid-template-columns: 1fr; }
-}
-
-.interactive-frame {
-    background: #fff; border: 2px solid var(--primary-blue);
-    border-radius: 20px; height: 500px; overflow: hidden;
-    box-shadow: 0 10px 30px rgba(0,0,0,0.1);
-}
-
-.interactive-frame iframe { width: 100%; height: 100%; border: none; }
-
-.theory-box {
-    background: var(--card-bg); padding: 30px; border-radius: 20px;
-    border-left: 5px solid var(--primary-blue);
-}
-
-.property-list { margin-top: 20px; }
-.property-item {
-    padding: 10px 0; border-bottom: 1px dashed #ddd;
-    display: flex; align-items: flex-start; gap: 10px;
-}
-.property-item::before { content: "✅"; }
 
 @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(20px); }
-    to { opacity: 1; transform: translateY(0); }
+    from {
+        opacity: 0;
+        transform: translateY(16px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
-/* 文化板块容器 */
-#culture {
-    margin: 60px 0;
-    padding: 20px;
-}
-
-.culture-header {
-    margin-bottom: 20px;
-    border-bottom: 2px solid #eef0f2;
-    padding-bottom: 10px;
-}
-
-.culture-tag {
-    background: #f0f4ff;
-    color: var(--primary-blue);
-    padding: 6px 15px;
-    border-radius: 20px;
-    font-weight: bold;
-    font-size: 0.9rem;
-    border: 1px solid #d0deff;
-}
-
-.culture-cards-container {
-    display: flex;
-    flex-direction: column;
-    gap: 30px;
-}
-
-/* 人物志卡片基础样式 */
-.bio-card {
-    display: flex;
-    background: #ffffff;
-    border: 1px solid #e0e0e0;
-    border-radius: 20px;
-    overflow: hidden;
-    box-shadow: 0 4px 15px rgba(0,0,0,0.05);
-    transition: 0.3s ease;
-}
-
-[data-theme="dark"] .bio-card {
-    background: #252525;
-    border-color: #444;
-    color: #eee;
-}
-
-.bio-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 10px 25px rgba(0,0,0,0.1);
-}
-
-/* 左侧图片区 */
-.bio-image {
-    flex: 0 0 250px; /* 固定宽度 */
-    background: #f8f9fa;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-right: 1px solid #eee;
-}
-
-.bio-image img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover; /* 自动填充不变形 */
-}
-
-/* 右侧信息区 */
-.bio-info {
-    padding: 30px;
-    flex: 1;
-    text-align: left;
-}
-
-.bio-name {
-    margin-top: 0;
-    color: var(--primary-blue);
-    font-size: 1.8rem;
-    margin-bottom: 15px;
-}
-
-.bio-meta p {
-    margin: 5px 0;
-    font-size: 0.95rem;
-    color: #666;
-}
-
-[data-theme="dark"] .bio-meta p { color: #aaa; }
-
-.bio-intro {
-    margin-top: 20px;
-    line-height: 1.8;
-    border-top: 1px solid #f0f0f0;
-    padding-top: 15px;
-}
-
-/* 响应式：手机端变回上下布局 */
-@media (max-width: 768px) {
-    .bio-card { flex-direction: column; }
-    .bio-image { flex: 0 0 200px; border-right: none; border-bottom: 1px solid #eee; }
-}
-.bio-image {
-    flex: 0 0 250px;
-    background: #f8f9fa;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    overflow: hidden; /* 防止图片超出边界 */
-}
-
-.bio-image img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover; /* 重要：让图片自动充满格子且不变形 */
-    display: block;    /* 确保不是隐藏状态 */
-}
-.interactive-frame iframe {
-    width: 100%;
-    height: 100%;
-    border: none;
-    background: #fff;
-}
-
-/* 详情页的渐变点缀 */
-.theory-box h3 {
-    color: var(--primary-blue);
-    margin-bottom: 15px;
-    border-bottom: 2px solid #eee;
-    display: inline-block;
-}
-.interactive-frame {
-    background: #fdfdfd;
-    border: 2px solid var(--primary-blue);
-    border-radius: 20px;
-    height: 550px; /* 强制给一个高度 */
-    width: 100%;
-    overflow: hidden;
-    box-shadow: 0 10px 30px rgba(0,0,0,0.08);
-}
-
-
-.detail-layout { display: grid; grid-template-columns: 1.8fr 1fr; gap: 30px; align-items: start; }
-
-/* 左侧交互区 */
-.interactive-container-pro {
-    background: #fff; border: 3px solid #eee; border-radius: 24px;
-    height: 550px; position: relative; overflow: hidden;
-    box-shadow: 0 20px 50px rgba(0,0,0,0.1); transition: 0.3s;
-}
-.interactive-container-pro:hover { border-color: var(--primary-blue); }
-
-/* 加载动画 */
-.loader-box {
-    position: absolute; top: 0; left: 0; width: 100%; height: 100%;
-    background: #f8f9fa; display: flex; flex-direction: column;
-    justify-content: center; align-items: center; z-index: 1;
-}
-.spinner {
-    width: 50px; height: 50px; border: 5px solid #ddd;
-    border-top: 5px solid var(--primary-blue); border-radius: 50%;
-    animation: spin 1s linear infinite; margin-bottom: 15px;
-}
-@keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
-
-/* 右侧卡片（玻璃拟态） */
-.glass-card {
-    background: rgba(255,255,255,0.8); backdrop-filter: blur(10px);
-    border: 1px solid rgba(0,0,0,0.05); padding: 25px; border-radius: 20px;
-    margin-bottom: 20px; box-shadow: 0 10px 20px rgba(0,0,0,0.03);
-}
-.side-title { color: var(--primary-blue); margin-bottom: 15px; display: flex; align-items: center; gap: 10px; }
-.desc-text { line-height: 1.8; color: #555; font-size: 1.05rem; }
-
-.prop-list-pro .property-item {
-    background: #f0f7ff; color: #0056b3; padding: 12px;
-    border-radius: 12px; margin-bottom: 10px; font-weight: 500;
-}
-
-.control-btn {
-    background: #eee; border: none; padding: 10px 20px; border-radius: 10px;
-    cursor: pointer; margin-right: 10px; margin-top: 20px; transition: 0.3s;
-}
-.control-btn:hover { background: #ddd; }
-
-/* 响应式 */
-@media (max-width: 900px) { .detail-layout { grid-template-columns: 1fr; } }
-.interactive-container-pro {
-    background: #fff; border: 2px solid var(--primary-blue); border-radius: 20px;
-    height: 550px; position: relative; overflow: hidden;
-}
-.loader-box {
-    position: absolute; top: 0; left: 0; width: 100%; height: 100%;
-    background: #f8f9fa; display: flex; flex-direction: column;
-    justify-content: center; align-items: center; z-index: 5;
-}
-/* 定理折叠项基础样式 */
-.accordion-item {
-    border: 1px solid #e0e0e0;
-    border-radius: 15px;
-    margin-bottom: 20px;
-    background: var(--card-bg);
-    overflow: hidden;
-    transition: 0.3s;
-}
-
-/* 每一行的标题栏 */
-.accordion-header {
-    padding: 20px 30px;
-    background: #f8f9fa;
-    cursor: pointer;
-    font-size: 1.25rem;
-    font-weight: bold;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-[data-theme="dark"] .accordion-header { background: #333; }
-
-/* 展开后的内容区：左图右文布局 */
-.accordion-content {
-    display: none; /* 默认隐藏 */
-    padding: 25px;
-    grid-template-columns: 1.6fr 1fr; /* 左侧占1.6份，右侧占1份 */
-    gap: 30px;
-    border-top: 1px solid #eee;
-    background: #fff;
-}
-[data-theme="dark"] .accordion-content { background: #1a1a1a; }
-
-/* 激活状态 */
-.accordion-item.active { border-color: var(--primary-blue); box-shadow: 0 10px 30px rgba(0,123,255,0.1); }
-.accordion-item.active .accordion-content { display: grid; }
-.accordion-item.active .accordion-header { background: var(--primary-blue); color: white; }
-
-/* 左侧 Demo 容器高度 */
-.demo-container {
-    height: 500px;
-    border: 1px solid #ddd;
-    border-radius: 10px;
-    overflow: hidden;
-    background: #fdfdfd;
-}
-.demo-container iframe { width: 100%; height: 100%; border: none; }
-
-/* 右侧文字区 */
-.info-container h3 { color: var(--primary-blue); margin-top: 0; }
-.info-container p { line-height: 1.6; color: var(--text-color); }
-
-/* 手机端适配：变为上下排布 */
-@media (max-width: 900px) {
-    .accordion-content { grid-template-columns: 1fr; }
-    .demo-container { height: 350px; }
-}
-/* 盒子必须有固定高度，图才能出来 */
-.demo-container {
-    min-height: 500px; /* 强制高度 */
-    background: #fdfdfd;
-    border: 1px solid #eee;
-    border-radius: 8px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-/* 隐藏旧版多余的文字干扰 */
-.info-container {
-    text-align: left;
-}
-
-.property-item {
-    background: #eef5ff;
-    padding: 10px;
-    border-radius: 8px;
-    margin-bottom: 8px;
-    font-size: 0.95rem;
-    color: #0056b3;
-}
-.demo-container {
-    background: #ffffff;
-    border-radius: 12px;
-    padding: 20px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 300px;
-}
-
-.demo-container svg {
-    width: 100%;
-    max-width: 300px; /* 控制图形不要太大 */
-    height: auto;
-}
-
-.accordion-item.active .accordion-content {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 30px;
-    padding: 30px;
-}
-
-@media (max-width: 768px) {
-    .accordion-item.active .accordion-content {
+@media (max-width: 980px) {
+    .bio-card,
+    .accordion-content {
         grid-template-columns: 1fr;
     }
-}
-/* 缩小整体宽度和边距 */
-#theorems-accordion-container {
-    max-width: 900px; /* 限制最大宽度，防止在大屏幕上显得空 */
-    margin: 0 auto;
-}
 
-.accordion-item {
-    border: 1px solid #eef0f2;
-    margin-bottom: 12px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
-}
-
-/* 布局调整：左侧图形占 45%，右侧文字占 55% */
-/* 默认（手机端）：垂直堆叠布局 */
-.accordion-item.active .accordion-content {
-    display: grid;
-    grid-template-columns: 1fr; /* 手机端只有一列 */
-    gap: 20px;
-    padding: 20px;
-    background: #fff;
-}
-
-/* 桌面端（屏幕宽度 > 768px）：恢复左右布局 */
-@media (min-width: 768px) {
-    .accordion-item.active .accordion-content {
-        /* 将固定 320px 改为比例，或者使用 minmax 确保不会撑破 */
-        grid-template-columns: minmax(300px, 1fr) 1.5fr;
-        align-items: center; /* 左右垂直居中对齐，更美观 */
-    }
-
-    .demo-container {
-        height: 350px; /* 桌面端可以高一点 */
+    .bio-image {
+        min-height: 220px;
     }
 }
 
-/* 图形容器优化 */
-.demo-container {
-    background: #fdfdfd;
-    border-radius: 8px;
-    height: 250px; /* 手机端默认高度 */
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border: 1px solid #f0f0f0;
-    overflow: hidden; /* 防止 SVG 溢出 */
+@media (max-width: 760px) {
+    #hero h1 {
+        font-size: 2.4rem;
+    }
+
+    .video-container,
+    #culture,
+    .theorem-card,
+    .bio-info,
+    .pro-banner,
+    .accordion-header,
+    .accordion-content {
+        padding-left: 20px;
+        padding-right: 20px;
+    }
+
+    .ad-content {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .detail-back-row {
+        width: 100%;
+    }
+
+    .detail-back-button,
+    .control-btn {
+        width: 100%;
+    }
+
+    #chat-toggle-btn {
+        right: 16px;
+        bottom: 16px;
+    }
+
+    #ai-chat-widget {
+        right: 16px;
+        bottom: 88px;
+    }
 }
 
-/* 图形容器：增加浅灰色背景，显出边界 */
-.demo-container {
-    background: #fdfdfd;
-    border-radius: 8px;
-    height: 280px; /* 降低高度 */
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border: 1px solid #f0f0f0;
-}
+@media (max-width: 560px) {
+    .section-title {
+        font-size: 1.9rem;
+    }
 
-.demo-container svg {
-    width: 240px; /* 缩小图形尺寸 */
-    height: 240px;
+    .pro-banner {
+        padding: 28px 22px;
+    }
 }
-
-/* 文字区微调 */
-.info-container {
-    padding: 10px 15px;
-    background: #fafbfc; /* 淡淡的底色 */
-    border-radius: 8px;
-}
-
-.info-container h3 {
-    font-size: 1.1rem;
-    margin: 10px 0 5px 0;
-}
-
-.property-item {
-    font-size: 0.9rem;
-    padding: 6px 10px;
-}
-/* 移除主页导航多余的间距 */
-.breadcrumb {
-    padding: 10px 0; /* 缩小一点 */
-    margin-bottom: 0;
-}
-
-/* 详情页导航：只留这一处修改 */
-.breadcrumb-pro {
-    background: transparent;
-    padding: 5px 0;      /* 👈 改小这个：原来是20px，缩减到5px，顶部间距立刻变小 */
-    border-bottom: 1px solid #eee;
-    margin-bottom: 10px; /* 👈 改小这个：原来是25px，缩减到10px，下方空隙立刻变小 */
-}
-
-.breadcrumb-pro .container {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 0.9rem;
-    color: #888;
-}
-
-.breadcrumb-pro a {
-    color: var(--primary-blue);
-    text-decoration: none;
-}
-
-.breadcrumb-pro #active-theorem-name {
-    color: #333;
-    font-weight: 700; /* 加粗当前定理名 */
-}
-/* --- 终极间距压缩方案 --- */
-
-/* 1. 强制消除主体容器顶部的死间距 */
-main.container {
-    padding-top: 0 !important;
-    margin-top: 0 !important;
-}
-
-/* 2. 强制消除详情页视图顶部的死间距 */
-#detail-view {
-    padding-top: 0 !important;
-    margin-top: 0 !important;
-}
-
-/* 3. 详情页导航条：极简高度，直接贴顶 */
-.breadcrumb-pro {
-    padding: 0 !important;       /* 彻底去掉内部高度 */
-    margin-top: 0 !important;    /* 彻底去掉上方外边距 */
-    margin-bottom: 10px !important; /* 调整它和下方定理标题的距离 */
-    border-bottom: 1px solid #f0f0f0;
-}
-
-/* 4. 这里的文字行高也压一下 */
-.breadcrumb-pro .container {
-    min-height: 30px !important; /* 强制这一行只有 30px 高 */
-    line-height: 30px;
-    display: flex;
-    align-items: center;
-}
-
-/* 5. 检查 Header 是否有底部外边距 */
-header {
-    margin-bottom: 0 !important;
-    padding-bottom: 5px !important; /* 稍微留一点呼吸感即可 */
-}
-/* =========================================
-   主题同步：暗黑模式适配
-   ========================================= */
-[data-theme="dark"] .breadcrumb-pro {
-    border-bottom-color: #444;
-}
-[data-theme="dark"] .breadcrumb-pro #active-theorem-name {
-    color: #fff; /* 暗黑模式下文字变白 */
-}
-[data-theme="dark"] .accordion-item {
-    border-color: #444;
-}
-[data-theme="dark"] .accordion-header {
-    background: #2d2d2d;
-    color: #eee;
-}
-[data-theme="dark"] .accordion-content {
-    background: #1a1a1a !important; /* 强制背景变深 */
-}
-[data-theme="dark"] .info-container {
-    background: #252525 !important; /* 文字区域变深 */
-}
-[data-theme="dark"] .info-container p,
-[data-theme="dark"] .info-container h3 {
-    color: #eee !important; /* 解决看不清定义文字的问题 */
-}
-[data-theme="dark"] .property-item {
-    background: #333;
-    border-color: #444;
-    color: #88ccff;
-}
-/* 暗黑模式下让 SVG 的黑色线条变白 */
-[data-theme="dark"] .demo-container svg circle[stroke="#333"],
-[data-theme="dark"] .demo-container svg path[stroke="#333"],
-[data-theme="dark"] .demo-container svg line[stroke="#333"] {
-    stroke: #eee !important;
-}
-
-/* =========================================
-   主题同步：高对比度模式适配 (黄色/黑色)
-   ========================================= */
-[data-a11y="high-contrast"] .accordion-header {
-    background: #000;
-    color: #ff0;
-    border: 2px solid #ff0;
-}
-[data-a11y="high-contrast"] .accordion-item.active .accordion-header {
-    background: #ff0;
-    color: #000;
-}
-[data-a11y="high-contrast"] .accordion-content,
-[data-a11y="high-contrast"] .info-container {
-    background: #000 !important;
-}
-[data-a11y="high-contrast"] .info-container p,
-[data-a11y="high-contrast"] .info-container h3 {
-    color: #ff0 !important;
-}
-/* 模态框通用遮罩 */
-.modal-overlay {
-    position: fixed;
-    top: 0; left: 0; width: 100%; height: 100%;
-    background: rgba(0, 0, 0, 0.7);
-    backdrop-filter: blur(8px);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 3000;
-}
-
-/* 隐私政策框特定样式 */
-.privacy-box {
-    max-width: 500px;
-    text-align: left !important;
-}
-
-.privacy-box ul {
-    padding-left: 20px;
-    margin: 15px 0;
-}
-
-.privacy-box li {
-    margin-bottom: 8px;
-    font-size: 0.95rem;
-}
-
-.close-modal {
-    position: absolute;
-    top: 15px; right: 20px;
-    font-size: 28px;
-    cursor: pointer;
-    opacity: 0.5;
-}
-
-.close-modal:hover { opacity: 1; color: var(--primary-blue); }
-
-/* 危险操作按钮 */
-.btn-danger {
-    background: #ff4757;
-    color: white;
-    border: none;
-    padding: 10px 20px;
-    border-radius: 25px;
-    font-weight: bold;
-    cursor: pointer;
-    margin-right: 10px;
-    transition: 0.3s;
-}
-
-.btn-danger:hover {
-    background: #ff6b81;
-    box-shadow: 0 5px 15px rgba(255, 71, 87, 0.4);
-}
-
-/* 暗黑模式适配 */
-[data-theme="dark"] .modal-content {
-    background: #252525;
-    border-color: #444;
-}
-
-/* 高对比度模式适配 */
-[data-a11y="high-contrast"] .modal-content {
-    background: #000 !important;
-    border: 3px solid #ff0 !important;
-    color: #ff0 !important;
-}
-[data-a11y="high-contrast"] .btn-danger {
-    border: 2px solid #ff0;
-    background: #000;
-    color: #ff0;
-}
-/* 遮罩层通用样式 */
-.modal-overlay {
-    position: fixed;
-    top: 0; left: 0; width: 100%; height: 100%;
-    background: rgba(0, 0, 0, 0.75);
-    backdrop-filter: blur(5px);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 4000;
-}
-
-.privacy-box {
-    text-align: left !important;
-    max-width: 500px;
-}
-
-/* 隐私政策内容微调 */
-#privacy-body h2 { color: var(--primary-blue); margin-bottom: 15px; }
-#privacy-body ul { padding-left: 20px; }
-#privacy-body li { margin-bottom: 10px; line-height: 1.5; }
-
-/* 暗黑模式下弹窗背景适配 */
-[data-theme="dark"] .modal-content {
-    background: #2d2d2d;
-    border-color: #444;
-}
-
-/* 高对比度模式下的危险按钮 */
-[data-a11y="high-contrast"] .btn-danger {
-    background: #000;
-    color: #ff0;
-    border: 2px solid #ff0;
-}
-
-/* 关闭按钮样式 */
-.close-modal {
-    position: absolute;
-    top: 15px; right: 20px;
-    font-size: 24px;
-    cursor: pointer;
-    opacity: 0.6;
-}
-.close-modal:hover { opacity: 1; }

--- a/css/quiz.css
+++ b/css/quiz.css
@@ -1,215 +1,65 @@
-/* css/home.css */
-:root {
-    --bg-color: #f4f7fc;
-    --text-color: #1e2b3c;
-    --header-bg: #ffffff;
-    --card-bg: #ffffff;
-    --border-color: #d0dae8;
-    --primary-color: #3a7bd5;
-    --primary-hover: #2b5fa8;
-    --secondary-bg: #e9eef4;
-    --shadow: 0 8px 20px rgba(0,0,0,0.05);
-    --canvas-bg: #ffffff;
-    --footer-bg: #1e2b3c;
-    --footer-text: #b0c4de;
-    --success-color: #2ecc71;
-    --error-color: #e74c3c;
-    --warning-color: #f39c12;
-}
-
-body.dark-mode {
-    --bg-color: #121826;
-    --text-color: #e3e9f2;
-    --header-bg: #1f2a3c;
-    --card-bg: #1f2a3c;
-    --border-color: #2e3a4e;
-    --primary-color: #5a9cff;
-    --primary-hover: #7db0ff;
-    --secondary-bg: #2a3648;
-    --canvas-bg: #1a2332;
-    --footer-bg: #0b1017;
-    --footer-text: #8a9bb5;
-    --shadow: 0 8px 20px rgba(0,0,0,0.3);
-}
-
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-}
-
-body {
-    font-family: 'Segoe UI', Roboto, system-ui, sans-serif;
-    background: var(--bg-color);
-    color: var(--text-color);
-    line-height: 1.5;
-    transition: background 0.2s, color 0.2s;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-}
-
-.container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 20px;
-    width: 100%;
-}
-
-/* accessibility bar */
-#accessibility-bar {
-    background: var(--header-bg);
-    border-bottom: 1px solid var(--border-color);
-    padding: 8px 0;
-}
-
-#accessibility-bar .container {
-    display: flex;
-    gap: 12px;
-    justify-content: flex-end;
-    flex-wrap: wrap;
-}
-
-#accessibility-bar button {
-    background: transparent;
-    border: 1px solid var(--border-color);
-    padding: 6px 12px;
-    border-radius: 30px;
-    font-size: 0.9rem;
-    cursor: pointer;
-    color: var(--text-color);
-    transition: all 0.15s;
-    font-weight: 500;
-}
-
-#accessibility-bar button:hover {
-    background: var(--primary-color);
-    color: white;
-    border-color: var(--primary-color);
-}
-
-/* header */
-header {
-    background: var(--header-bg);
-    padding: 18px 0;
-    border-bottom: 1px solid var(--border-color);
-    box-shadow: var(--shadow);
-}
-
-.header-content {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: wrap;
-}
-
-.logo {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 1.8rem;
-    font-weight: 700;
-    text-decoration: none;
-    color: var(--text-color);
-}
-
-.logo-icon {
-    background: var(--primary-color);
-    color: white;
-    width: 40px;
-    height: 40px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 50%;
-    font-size: 1.8rem;
-}
-
-.nav-links {
-    display: flex;
-    list-style: none;
-    gap: 28px;
-}
-
-.nav-links a {
-    text-decoration: none;
-    font-weight: 600;
-    color: var(--text-color);
-    font-size: 1.1rem;
-    padding: 6px 0;
-    border-bottom: 2px solid transparent;
-    transition: 0.2s;
-}
-
-.nav-links a.active, .nav-links a:hover {
-    border-bottom-color: var(--primary-color);
-    color: var(--primary-color);
-}
-
-/* breadcrumb */
-.breadcrumb {
-    margin: 20px 0 10px;
-    font-size: 0.95rem;
-    color: var(--text-color);
-    opacity: 0.8;
-}
-
-.breadcrumb a {
-    color: var(--primary-color);
-    text-decoration: none;
-}
-
-/* main quiz section */
 .quiz-layout {
     display: grid;
-    grid-template-columns: 2fr 1fr;
+    grid-template-columns: minmax(0, 1fr) auto;
     gap: 24px;
-    margin: 20px 0 40px;
+    align-items: start;
+}
+
+.quiz-area,
+.quiz-panel,
+.level-fieldset {
+    min-width: 0;
 }
 
 .quiz-area {
     background: var(--card-bg);
+    border: 1px solid var(--border-color);
     border-radius: 28px;
     padding: 24px;
     box-shadow: var(--shadow);
-    border: 1px solid var(--border-color);
 }
 
 #circle-canvas {
-    background: var(--canvas-bg);
-    min-height: 320px;
-    border-radius: 20px;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: 20px;
+    gap: 20px;
+    min-height: 320px;
+    padding: 24px;
     border: 1px dashed var(--border-color);
-    transition: background 0.2s;
-}
-
-#circle-canvas p {
-    font-size: 1.3rem;
-    margin-bottom: 25px;
-    font-weight: 500;
-}
-
-#circle-canvas input {
-    width: 220px;
-    padding: 14px 18px;
-    border: 2px solid var(--border-color);
-    border-radius: 60px;
-    font-size: 1.1rem;
-    background: var(--card-bg);
-    color: var(--text-color);
-    outline: none;
-    transition: 0.2s;
+    border-radius: 22px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(233, 238, 244, 0.95));
     text-align: center;
 }
 
-#circle-canvas input:focus {
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 3px rgba(58, 123, 213, 0.2);
+[data-theme="dark"] #circle-canvas {
+    background: linear-gradient(180deg, rgba(31, 42, 60, 0.92), rgba(37, 50, 70, 0.98));
+}
+
+#circle-canvas p {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--primary-blue);
+}
+
+#answer-input {
+    width: min(280px, 100%);
+    padding: 14px 18px;
+    border: 2px solid var(--border-color);
+    border-radius: 999px;
+    background: var(--card-bg);
+    color: var(--text-color);
+    font: inherit;
+    text-align: center;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+#answer-input:focus {
+    outline: none;
+    border-color: var(--primary-blue);
+    box-shadow: 0 0 0 4px rgba(58, 123, 213, 0.16);
 }
 
 .quiz-panel {
@@ -220,137 +70,134 @@ header {
 
 .panel-card {
     background: var(--card-bg);
-    padding: 24px 20px;
-    border-radius: 24px;
-    box-shadow: var(--shadow);
     border: 1px solid var(--border-color);
+    border-radius: 24px;
+    padding: 24px 20px;
+    box-shadow: var(--shadow);
 }
 
 .control-card {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    display: grid;
+    gap: 14px;
+    min-width: 220px;
 }
 
-button {
-    background: var(--primary-color);
-    color: white;
-    border: none;
-    padding: 14px 18px;
-    border-radius: 48px;
-    font-size: 1.1rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: 0.2s;
+.control-card button,
+#feedback-btn {
+    width: 100%;
     border: 1px solid transparent;
+    border-radius: 999px;
+    padding: 12px 16px;
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
 }
 
-button.secondary-btn {
-    background: var(--secondary-bg);
-    color: var(--text-color);
-    border: 1px solid var(--border-color);
+.control-card button,
+#next-btn,
+#feedback-btn {
+    background: var(--primary-blue);
+    color: #ffffff;
 }
 
-button:hover {
-    background: var(--primary-hover);
+.control-card button:hover,
+#feedback-btn:hover {
     transform: translateY(-2px);
-    box-shadow: 0 6px 12px rgba(0,0,0,0.1);
+    box-shadow: 0 10px 22px rgba(58, 123, 213, 0.18);
 }
 
-button.secondary-btn:hover {
-    background: var(--border-color);
+.control-card .secondary-btn {
+    background: transparent;
+    color: var(--text-color);
+    border-color: var(--border-color);
 }
 
-/* level & feedback row */
-.quiz-layout label {
-    font-weight: 600;
-    margin-right: 6px;
+.control-card .secondary-btn:hover {
+    background: rgba(58, 123, 213, 0.1);
 }
 
-.quiz-layout input[type="radio"] {
-    margin-right: 4px;
-    accent-color: var(--primary-color);
+.level-fieldset {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin: 0;
+    padding: 18px 20px;
+    border: 1px solid var(--border-color);
+    border-radius: 24px;
+    background: var(--card-bg);
+    box-shadow: var(--shadow);
+}
+
+.level-fieldset legend {
+    padding: 0 8px;
+    font-weight: 700;
+    color: var(--primary-blue);
+}
+
+.level-fieldset input[type="radio"] {
+    margin: 0;
+    accent-color: var(--primary-blue);
     transform: scale(1.1);
 }
 
-#feedback-btn {
-    background: var(--secondary-bg);
-    color: var(--text-color);
-    margin-left: 16px;
-    padding: 10px 20px;
-    border-radius: 40px;
-    font-size: 1rem;
+.level-fieldset label {
+    margin-right: 12px;
+    font-weight: 600;
 }
 
-/* result / analysis inline */
+#feedback-btn {
+    min-width: 180px;
+    align-self: start;
+}
+
 .answer-feedback {
-    margin-top: 20px;
-    padding: 12px 18px;
-    border-radius: 40px;
-    font-weight: 500;
+    width: min(100%, 360px);
+    margin-top: 8px;
+    padding: 12px 16px;
+    border-radius: 18px;
     background: var(--secondary-bg);
+    border: 1px solid var(--border-color);
+    font-weight: 600;
     text-align: center;
 }
 
 .analysis-text {
-    margin-top: 15px;
-    font-style: italic;
-    border-left: 4px solid var(--primary-color);
-    padding-left: 18px;
+    width: min(100%, 420px);
+    margin-top: 8px;
+    padding: 16px 18px;
+    border-left: 4px solid var(--primary-blue);
+    border-radius: 0 18px 18px 0;
     background: var(--secondary-bg);
-    border-radius: 0 20px 20px 0;
     line-height: 1.6;
 }
 
-/* footer */
-footer {
-    background: var(--footer-bg);
-    color: var(--footer-text);
-    padding: 30px 0;
-    margin-top: auto;
-}
-
-.footer-content {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 15px;
-}
-
-.footer-links a {
-    color: var(--footer-text);
-    text-decoration: none;
-    margin-left: 28px;
-    transition: color 0.2s;
-}
-
-.footer-links a:hover {
-    color: white;
-}
-
-/* responsive */
-@media (max-width: 700px) {
+@media (max-width: 980px) {
     .quiz-layout {
         grid-template-columns: 1fr;
     }
-    .header-content {
-        flex-direction: column;
-        gap: 10px;
-    }
-    .footer-content {
-        flex-direction: column;
-        text-align: center;
-    }
-    .footer-links a {
-        margin: 0 12px;
+
+    .level-fieldset,
+    #feedback-btn {
+        width: 100%;
     }
 }
 
-/* utility for font adjustment (applied to body) */
-body.font-large {
-    font-size: 1.2rem;
-}
-body.font-small {
-    font-size: 0.9rem;
+@media (max-width: 760px) {
+    .quiz-area,
+    .panel-card,
+    .level-fieldset {
+        padding: 20px;
+        border-radius: 22px;
+    }
+
+    #circle-canvas {
+        min-height: 280px;
+        padding: 20px;
+    }
+
+    .level-fieldset {
+        gap: 8px 12px;
+    }
 }

--- a/game.html
+++ b/game.html
@@ -4,12 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CircleMaster - Geometry Lab</title>
+    <link rel="stylesheet" href="css/global.css">
     <link rel="stylesheet" href="css/game.css">
 </head>
 <body>
     <div id="accessibility-bar">
         <div class="container">
             <button type="button" onclick="changeLanguage()" data-i18n="btn-lang">EN / 中</button>
+            <button type="button" onclick="toggleContrast()" data-i18n="btn-contrast">Contrast</button>
             <button type="button" onclick="adjustFontSize(1)">A+</button>
             <button type="button" onclick="adjustFontSize(-1)">A-</button>
             <button id="theme-btn" type="button">
@@ -29,7 +31,11 @@
                 <span class="logo-icon">C</span>
                 <span data-i18n="logo-text">CircleMaster</span>
             </a>
-            <nav>
+            <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="game-site-nav" data-nav-toggle>
+                <span class="nav-toggle-icon">☰</span>
+                <span data-nav-toggle-label>Menu</span>
+            </button>
+            <nav id="game-site-nav" class="site-nav" data-site-nav>
                 <ul class="nav-links">
                     <li><a href="index.html" data-i18n="nav-home">Home</a></li>
                     <li><a href="game.html" class="active" data-i18n="nav-game">Game</a></li>
@@ -40,9 +46,9 @@
     </header>
 
     <div class="container">
-        <nav class="breadcrumb">
+        <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="index.html" data-i18n="bc-home">Home</a>
-            &nbsp;>&nbsp;
+            <span class="breadcrumb-separator" aria-hidden="true">&gt;</span>
             <span data-i18n="bc-current">Game: Geometry Lab</span>
         </nav>
     </div>
@@ -188,14 +194,22 @@
 
     <footer>
         <div class="container footer-content">
-            <p data-i18n="footer-copy">© 2026 Group 33. All rights reserved.</p>
+            <p data-i18n="footer-copy">© 2026 25/26_EBU5315_G19. All rights reserved.</p>
             <div class="footer-links">
-                <a href="#" data-i18n="footer-data">Data Policy</a>
-                <a href="#" data-i18n="footer-access">Accessibility</a>
-                <a href="#" data-i18n="footer-contact">Contact Us</a>
+                <a href="javascript:void(0)" onclick="openFooterModal('data')" data-i18n="footer-data">Data Policy</a>
+                <a href="javascript:void(0)" onclick="openFooterModal('access')" data-i18n="footer-access">Accessibility</a>
+                <a href="javascript:void(0)" onclick="openFooterModal('contact')" data-i18n="footer-contact">Contact Us</a>
             </div>
         </div>
     </footer>
+
+    <div id="privacy-modal" class="modal-overlay" hidden>
+        <div class="modal-content privacy-box">
+            <button type="button" class="close-modal" onclick="togglePrivacyModal(false)" aria-label="Close dialog">&times;</button>
+            <div id="privacy-body"></div>
+            <button type="button" class="modal-close-btn" onclick="togglePrivacyModal(false)">OK / 确定</button>
+        </div>
+    </div>
 
     <script src="js/game.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CircleMaster - Interactive Geometry Learning</title>
+    <link rel="stylesheet" href="css/global.css">
     <link rel="stylesheet" href="css/home.css">
 </head>
 <body>
@@ -11,14 +12,17 @@
     <!-- 1. 顶部无障碍工具条 -->
     <div id="accessibility-bar">
         <div class="container">
-            <button onclick="changeLanguage()" data-i18n="btn-lang">EN / 中</button>
-            <button onclick="toggleContrast()" data-i18n="btn-contrast">👁️ Contrast</button>
-            <button onclick="adjustFontSize(1)">A+</button>
-            <button onclick="adjustFontSize(-1)">A-</button>
-            <button id="theme-btn" data-i18n="btn-theme">🌙 Dark Mode</button>
-            <!-- 声音按钮：图标和文字分开，防止被覆盖 -->
-            <button id="audio-btn" onclick="toggleSound()">
-                <span id="sound-icon">🔊</span> <span data-i18n="btn-sound">Sound</span>
+            <button type="button" onclick="changeLanguage()" data-i18n="btn-lang">EN / 中</button>
+            <button type="button" onclick="toggleContrast()" data-i18n="btn-contrast">Contrast</button>
+            <button type="button" onclick="adjustFontSize(1)">A+</button>
+            <button type="button" onclick="adjustFontSize(-1)">A-</button>
+            <button id="theme-btn" type="button">
+                <span id="theme-icon">🌙</span>
+                <span id="theme-label">Dark Mode</span>
+            </button>
+            <button id="audio-btn" type="button">
+                <span id="audio-icon">🔊</span>
+                <span id="audio-label">Sound On</span>
             </button>
         </div>
     </div>
@@ -29,7 +33,11 @@
             <a href="index.html" class="logo">
                 <span class="logo-icon">C</span> <span data-i18n="logo-text">CircleMaster</span>
             </a>
-            <nav>
+            <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="home-site-nav" data-nav-toggle>
+                <span class="nav-toggle-icon">☰</span>
+                <span data-nav-toggle-label>Menu</span>
+            </button>
+            <nav id="home-site-nav" class="site-nav" data-site-nav>
                 <ul class="nav-links">
                     <li><a href="index.html" class="active" data-i18n="nav-home">Home</a></li>
                     <li><a href="game.html" data-i18n="nav-game">Game</a></li>
@@ -44,9 +52,11 @@
 
         <!-- 视图 1：主页内容 (默认显示) -->
         <div id="main-view">
-            <nav class="breadcrumb">
-        <a href="index.html" data-i18n="bc-home">Home</a>
-    </nav>
+            <nav class="breadcrumb" aria-label="Breadcrumb">
+                <a href="index.html" data-i18n="bc-home">Home</a>
+                <span class="breadcrumb-separator" aria-hidden="true">&gt;</span>
+                <span data-i18n="bc-current-home">Overview</span>
+            </nav>
             <!-- 4. Hero Section -->
             <section id="hero">
                 <h1 data-i18n="hero-title">Master Circle Geometry <br><span class="highlight">Powered by AI</span></h1>
@@ -177,23 +187,21 @@
         </div> <!-- End of main-view -->
 
   <!-- 视图 2：定理详情 -->
-    <div id="detail-view" style="display: none;">
-    <nav class="breadcrumb-pro">
-        <div class="container">
+    <div id="detail-view" hidden>
+        <nav class="breadcrumb" aria-label="Breadcrumb">
             <a href="javascript:void(0)" onclick="hideDetail()" data-i18n="bc-home">Home</a>
-            <span class="sep">/</span>
+            <span class="breadcrumb-separator" aria-hidden="true">&gt;</span>
             <span data-i18n="bc-gallery">Gallery</span>
-            <span class="sep">/</span>
-            <span id="active-theorem-name" style="font-weight: bold; color: #333;">Theorem</span>
-        </div>
-    </nav>
+            <span class="breadcrumb-separator" aria-hidden="true">&gt;</span>
+            <span id="active-theorem-name" class="breadcrumb-current">Theorem</span>
+        </nav>
 
         <div class="container" id="theorems-accordion-container">
             <!-- 定理列表会自动在这里生成 -->
         </div>
 
-        <div class="container" style="text-align: center; margin: 40px 0;">
-            <button onclick="hideDetail()" class="control-btn" style="padding: 12px 30px; border-radius: 30px; background: #666; color: #fff; border: none; cursor: pointer;">← Back to Home</button>
+        <div class="container detail-back-row">
+            <button type="button" onclick="hideDetail()" class="control-btn detail-back-button" data-i18n="btn-back">← Back to Home</button>
         </div>
     </div>
 
@@ -202,13 +210,12 @@
     <!-- 7. AI 聊天室 -->
     <div id="chat-toggle-btn" onclick="toggleChat()">🤖</div>
 
-    <div id="ai-chat-widget" style="display: none;">
+    <div id="ai-chat-widget" hidden>
         <div class="chat-header">
             <span data-i18n="chat-header">Circle AI Tutor</span>
-            <div style="float:right">
-                <!-- 🗑️ 绑定到确认框函数 -->
-                <button onclick="confirmClearChat()" style="background:none;border:none;color:white;cursor:pointer">🗑️</button>
-                <button onclick="toggleChat()" style="background:none;border:none;color:white;cursor:pointer">✕</button>
+            <div class="chat-actions">
+                <button type="button" class="chat-icon-btn" onclick="confirmClearChat()" aria-label="Clear chat">🗑️</button>
+                <button type="button" class="chat-icon-btn" onclick="toggleChat()" aria-label="Close chat">✕</button>
             </div>
         </div>
         <div class="chat-body" id="chat-body">
@@ -221,38 +228,35 @@
 
     <!-- 8. Version 4 新增：隐私政策与二次确认弹窗 -->
     <!-- 二次确认弹窗 -->
-    <div id="confirm-modal" class="modal-overlay" style="display: none;">
+    <div id="confirm-modal" class="modal-overlay" hidden>
         <div class="modal-content">
             <h3 data-i18n="modal-title">Confirm?</h3>
             <p data-i18n="modal-desc">Clear all messages?</p>
-            <div style="margin-top:20px">
-                <!-- 对接 JS 中的 executeClear 函数 -->
+            <div class="modal-actions">
                 <button onclick="executeClear()" class="btn-danger" data-i18n="btn-confirm">Delete</button>
-                <button onclick="closeModal()" data-i18n="btn-cancel">Cancel</button>
+                <button onclick="closeModal()" class="modal-close-btn" data-i18n="btn-cancel">Cancel</button>
             </div>
         </div>
     </div>
 
     <!-- 隐私政策弹窗 -->
-    <div id="privacy-modal" class="modal-overlay" style="display: none;">
+    <div id="privacy-modal" class="modal-overlay" hidden>
         <div class="modal-content privacy-box">
-            <span class="close-modal" onclick="togglePrivacyModal(false)">&times;</span>
+            <button type="button" class="close-modal" onclick="togglePrivacyModal(false)" aria-label="Close dialog">&times;</button>
             <div id="privacy-body">
                 <!-- 内容由 JS 根据语言动态填充 -->
             </div>
-            <button class="learn-more" onclick="togglePrivacyModal(false)" style="margin-top:20px">OK / 确定</button>
+            <button class="modal-close-btn" onclick="togglePrivacyModal(false)">OK / 确定</button>
         </div>
     </div>
 
     <footer>
         <div class="container footer-content">
-            <p data-i18n="footer-copy">© 2026 Group 33. All rights reserved.</p>
+            <p data-i18n="footer-copy">© 2026 25/26_EBU5315_G19. All rights reserved.</p>
             <div class="footer-links">
-                <!-- 三个链接都绑定到新函数 -->
-            <a href="javascript:void(0)" onclick="openFooterModal('data')" data-i18n="footer-data">Data Policy</a>
-            <a href="javascript:void(0)" onclick="openFooterModal('access')" data-i18n="footer-access">Accessibility</a>
-            <a href="javascript:void(0)" onclick="openFooterModal('contact')" data-i18n="footer-contact">Contact Us</a>
-
+                <a href="javascript:void(0)" onclick="openFooterModal('data')" data-i18n="footer-data">Data Policy</a>
+                <a href="javascript:void(0)" onclick="openFooterModal('access')" data-i18n="footer-access">Accessibility</a>
+                <a href="javascript:void(0)" onclick="openFooterModal('contact')" data-i18n="footer-contact">Contact Us</a>
             </div>
         </div>
     </footer>

--- a/js/game.js
+++ b/js/game.js
@@ -1,6 +1,7 @@
 const translations = {
     en: {
         'btn-lang': 'EN / 中',
+        'btn-contrast': 'Contrast',
         'theme-dark': 'Dark Mode',
         'theme-light': 'Light Mode',
         'audio-on': 'Sound On',
@@ -167,13 +168,16 @@ const translations = {
         'chat-reply-same-arc': 'Angles standing on the same arc share the same measure, even when their points move.',
         'chat-reply-semicircle': 'A diameter creates a semicircle, and any point on that semicircle forms a 90° angle.',
         'chat-reply-default': 'Pick a theorem mode, drag a blue point, and watch the measurement panel explain the invariant.',
-        'footer-copy': '© 2026 Group 33. All rights reserved.',
+        'nav-toggle-label': 'Menu',
+        'modal-close': 'OK',
+        'footer-copy': '© 2026 25/26_EBU5315_G19. All rights reserved.',
         'footer-data': 'Data Policy',
         'footer-access': 'Accessibility',
         'footer-contact': 'Contact Us'
     },
     zh: {
         'btn-lang': '中 / EN',
+        'btn-contrast': '对比度',
         'theme-dark': '黑夜模式',
         'theme-light': '明亮模式',
         'audio-on': '声音开启',
@@ -340,7 +344,9 @@ const translations = {
         'chat-reply-same-arc': '同弧所对的角相等，即使对应点移动，角度也会保持一致。',
         'chat-reply-semicircle': '直径形成半圆，半圆上的任意点都会构成 90° 圆周角。',
         'chat-reply-default': '请选择一个定理模式，拖动蓝色点，并观察测量面板中的不变量。',
-        'footer-copy': '© 2026 第33组。保留所有权利。',
+        'nav-toggle-label': '菜单',
+        'modal-close': '确定',
+        'footer-copy': '© 2026 25/26_EBU5315_G19. 保留所有权利。',
         'footer-data': '数据政策',
         'footer-access': '无障碍声明',
         'footer-contact': '联系我们'
@@ -350,6 +356,7 @@ const translations = {
 let currentLang = 'en';
 let currentFontSize = 16;
 let soundEnabled = true;
+let currentFooterModalType = null;
 
 const TAU = Math.PI * 2;
 const SNAP_DISTANCE = 26;
@@ -475,16 +482,170 @@ function applyStaticTranslations() {
         node.setAttribute('aria-label', t(key));
     });
 
+    const navToggleLabel = document.querySelector('[data-nav-toggle-label]');
+    if (navToggleLabel) {
+        navToggleLabel.textContent = t('nav-toggle-label');
+    }
+
+    const privacyCloseButton = document.querySelector('#privacy-modal .modal-close-btn');
+    if (privacyCloseButton) {
+        privacyCloseButton.textContent = t('modal-close');
+    }
+
     updateThemeButton();
     updateAudioButton();
+
+    if (currentFooterModalType) {
+        const privacyModal = document.getElementById('privacy-modal');
+        const privacyBody = document.getElementById('privacy-body');
+        if (privacyModal && !privacyModal.hidden && privacyBody) {
+            privacyBody.innerHTML = footerModalContent(currentFooterModalType);
+        }
+    }
+
     applyStatus();
 }
 
 function adjustFontSize(delta) {
     currentFontSize += delta * 2;
     if (currentFontSize < 12) currentFontSize = 12;
-    if (currentFontSize > 30) currentFontSize = 30;
+    if (currentFontSize > 26) currentFontSize = 26;
     document.documentElement.style.setProperty('--font-size-base', `${currentFontSize}px`);
+}
+
+function toggleContrast() {
+    const isHighContrast = document.documentElement.getAttribute('data-a11y') === 'high-contrast';
+    if (isHighContrast) {
+        document.documentElement.removeAttribute('data-a11y');
+    } else {
+        document.documentElement.setAttribute('data-a11y', 'high-contrast');
+    }
+}
+
+function setNavOpen(isOpen) {
+    const navToggle = document.querySelector('[data-nav-toggle]');
+    const siteNav = document.querySelector('[data-site-nav]');
+    if (!navToggle || !siteNav) return;
+
+    siteNav.classList.toggle('is-open', isOpen);
+    navToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+}
+
+function syncBodyLock() {
+    const privacyModal = document.getElementById('privacy-modal');
+    document.body.style.overflow = privacyModal && !privacyModal.hidden ? 'hidden' : '';
+}
+
+function footerModalContent(type) {
+    if (currentLang === 'zh') {
+        if (type === 'data') {
+            return `
+                <h2>数据政策</h2>
+                <p>CircleMaster 仅用于教学演示。我们承诺以透明、最小化的方式处理站点偏好和交互内容。</p>
+                <ul>
+                    <li><strong>实时处理：</strong> 页面内 AI 提示和交互内容仅在当前浏览器会话中使用。</li>
+                    <li><strong>个人信息：</strong> 我们不会在站点中主动收集、出售或共享你的个人信息。</li>
+                    <li><strong>联系方式：</strong> 如需反馈，请发送邮件至 2024213571@bupt.cn。</li>
+                </ul>
+                <div class="preference-note"><strong>偏好说明：</strong> 主题、字体和无障碍设置由浏览器当前页面即时应用。</div>
+            `;
+        }
+        if (type === 'access') {
+            return `
+                <h2>无障碍说明</h2>
+                <p>我们希望 Home、Game、Quiz 三页都提供一致且可理解的学习体验。</p>
+                <ul>
+                    <li><strong>视觉支持：</strong> 支持黑夜模式、高对比度和字体缩放。</li>
+                    <li><strong>结构一致：</strong> 统一导航、面包屑和页脚，降低跨页切换成本。</li>
+                    <li><strong>持续改进：</strong> 如发现可读性或操作问题，欢迎联系团队反馈。</li>
+                </ul>
+            `;
+        }
+        return `
+            <h2>联系我们</h2>
+            <p>如果你对课程内容、设计实现或无障碍细节有建议，欢迎联系我们。</p>
+            <ul>
+                <li><strong>项目反馈：</strong> 可通过仓库 Issue 或邮件提交问题。</li>
+                <li><strong>响应方式：</strong> 我们会根据课程项目节奏尽快回复。</li>
+            </ul>
+        `;
+    }
+
+    if (type === 'data') {
+        return `
+            <h2>Data Policy</h2>
+            <p>CircleMaster is an educational prototype. We keep site messaging and preference handling simple and transparent.</p>
+            <ul>
+                <li><strong>Session-first behaviour:</strong> AI hints and page interactions stay within the current browser session.</li>
+                <li><strong>Personal data:</strong> We do not intentionally collect, sell, or share personal user data through this site.</li>
+                <li><strong>Contact:</strong> Reach the team at 2024213571@bupt.cn for questions or concerns.</li>
+            </ul>
+            <div class="preference-note"><strong>Preference note:</strong> Theme, font size, and accessibility controls apply directly in the browser for the current page.</div>
+        `;
+    }
+    if (type === 'access') {
+        return `
+            <h2>Accessibility Statement</h2>
+            <p>We aim to keep Home, Game, and Quiz visually consistent and easier to navigate for all learners.</p>
+            <ul>
+                <li><strong>Visual support:</strong> Dark mode, high contrast, and font scaling are available from the shared toolbar.</li>
+                <li><strong>Consistent structure:</strong> Navigation, breadcrumbs, and footer behaviour are aligned across pages.</li>
+                <li><strong>Feedback welcome:</strong> Please contact the team if a control is unclear or difficult to use.</li>
+            </ul>
+        `;
+    }
+    return `
+        <h2>Contact Us</h2>
+        <p>If you have feedback about the content, design, or accessibility details, please get in touch.</p>
+        <ul>
+            <li><strong>Project feedback:</strong> You can also raise an issue in the project repository.</li>
+            <li><strong>Response style:</strong> We will reply as quickly as the course project schedule allows.</li>
+        </ul>
+    `;
+}
+
+function openFooterModal(type) {
+    const privacyModal = document.getElementById('privacy-modal');
+    const privacyBody = document.getElementById('privacy-body');
+    if (!privacyModal || !privacyBody) return;
+
+    currentFooterModalType = type;
+    privacyBody.innerHTML = footerModalContent(type);
+    privacyModal.hidden = false;
+    setNavOpen(false);
+    syncBodyLock();
+}
+
+function togglePrivacyModal(show) {
+    const privacyModal = document.getElementById('privacy-modal');
+    if (!privacyModal) return;
+
+    privacyModal.hidden = !show;
+    if (!show) {
+        currentFooterModalType = null;
+    }
+    syncBodyLock();
+}
+
+function setupNavToggle() {
+    const navToggle = document.querySelector('[data-nav-toggle]');
+    const siteNav = document.querySelector('[data-site-nav]');
+    if (!navToggle || !siteNav) return;
+
+    navToggle.addEventListener('click', () => {
+        const isOpen = !siteNav.classList.contains('is-open');
+        setNavOpen(isOpen);
+    });
+
+    siteNav.querySelectorAll('a').forEach((link) => {
+        link.addEventListener('click', () => setNavOpen(false));
+    });
+
+    window.addEventListener('resize', () => {
+        if (window.innerWidth > 760) {
+            setNavOpen(false);
+        }
+    });
 }
 
 function changeLanguage() {
@@ -1659,12 +1820,27 @@ if (audioBtn) {
     });
 }
 
+const gamePrivacyModal = document.getElementById('privacy-modal');
+if (gamePrivacyModal) {
+    gamePrivacyModal.hidden = true;
+}
+syncBodyLock();
+
+applyStaticTranslations();
+setupNavToggle();
+
+window.changeLanguage = changeLanguage;
+window.toggleContrast = toggleContrast;
+window.adjustFontSize = adjustFontSize;
+window.openFooterModal = openFooterModal;
+window.togglePrivacyModal = togglePrivacyModal;
+
 function initializeLab() {
     resetAllProgress();
-    applyStaticTranslations();
     setupActions();
     setupPointerEvents();
     setupChat();
+    applyStaticTranslations();
     renderBoard();
     pushLog('log-mode-title', getCurrentModeConfig().logIntroKey);
     refreshChatWelcome();

--- a/js/home.js
+++ b/js/home.js
@@ -1,611 +1,592 @@
-// --- 1. 双语字典 (已全面完善以适配新功能) ---
 const translations = {
-    'en': {
-        // 顶部与无障碍
-        'btn-lang': 'EN / 中', 'btn-contrast': '👁️ Contrast', 'btn-theme': '🌙 Dark Mode', 'btn-sound': 'Sound',
-        // 导航
-        'logo-text': 'CircleMaster', 'nav-home': 'Home', 'nav-game': 'Game', 'nav-quiz': 'Quiz',
-        'bc-home': 'Home', 'bc-gallery': 'Gallery',
-        // 主页 Hero
+    en: {
+        'btn-lang': 'EN / 中',
+        'btn-contrast': 'Contrast',
+        'logo-text': 'CircleMaster',
+        'nav-home': 'Home',
+        'nav-game': 'Game',
+        'nav-quiz': 'Quiz',
+        'bc-home': 'Home',
+        'bc-gallery': 'Gallery',
+        'bc-current-home': 'Overview',
         'hero-title': 'Master Circle Geometry <br><span class="highlight">Powered by AI</span>',
         'hero-usp': 'Interactive animations, AI-guided tutoring, and practice.',
-        // 学习中心卡片
         'hub-title': 'Interactive Theorem Gallery',
-        'rule1-title': 'Tangent-Radius', 'rule1-desc': 'Tangent is perpendicular to radius at contact point.',
-        'rule2-title': 'Angle at Center', 'rule2-desc': 'Center angle is twice the angle at circumference.',
-        'rule3-title': 'Cyclic Quads', 'rule3-desc': 'Opposite angles sum to 180 degrees.',
-        'rule4-title': 'Alternate Segment', 'rule4-desc': 'Angle between tangent and chord equals alternate segment angle.',
-        'rule5-title': 'Same Arc Theorem', 'rule5-desc': 'Angles subtended by the same arc are equal.',
-        'rule6-title': 'Semi-circle Angle', 'rule6-desc': 'The angle in a semi-circle is always 90 degrees.',
+        'rule1-title': 'Tangent-Radius',
+        'rule1-desc': 'Tangent is perpendicular to radius at contact point.',
+        'rule2-title': 'Angle at Center',
+        'rule2-desc': 'Center angle is twice the angle at circumference.',
+        'rule3-title': 'Cyclic Quads',
+        'rule3-desc': 'Opposite angles sum to 180 degrees.',
+        'rule4-title': 'Alternate Segment',
+        'rule4-desc': 'Angle between tangent and chord equals alternate segment angle.',
+        'rule5-title': 'Same Arc Theorem',
+        'rule5-desc': 'Angles subtended by the same arc are equal.',
+        'rule6-title': 'Semi-circle Angle',
+        'rule6-desc': 'The angle in a semi-circle is always 90 degrees.',
         'btn-learn': 'Explore Detail',
-        // 详情页/手风琴内部
-        'detail-explanation-title': 'Mathematical Explanation',
-        'side-tips': 'Key Takeaways',
-        'btn-back': 'Back to Home',
-        // 文化板块
+        'btn-back': '← Back to Home',
         'culture-label': 'Great Mathematicians',
-        'meta-nation': 'Nationality', 'meta-era': 'Era', 'meta-intro': 'Brief Intro',
-        'val-cn': 'Ancient China', 'val-gr': 'Ancient Greece',
-        'culture-zh': 'Calculated π with extreme precision, leading the world for 1000 years.',
-        'culture-gr': 'Used the method of exhaustion to approximate π, laying foundations of geometry.',
-        // 广告与 Pro
+        'meta-nation': 'Nationality',
+        'meta-era': 'Era',
+        'meta-intro': 'Intro',
+        'val-cn': 'Ancient China',
+        'val-gr': 'Ancient Greece',
+        'culture-zh': 'A world-renowned mathematician and astronomer. He calculated pi with extreme precision, a record that stood for over 1000 years.',
+        'culture-gr': 'Considered one of the greatest mathematicians of all time. He used the method of exhaustion to approximate pi and laid foundations for geometry.',
         'pro-title': 'Upgrade to CircleMaster Pro',
         'pro-desc': 'Get unlimited exercises and AI PDF summaries.',
         'pro-btn': 'Join Now',
-        // AI 聊天与弹窗
-        'chat-header': 'Circle AI Tutor', 'ai-name': 'AI: ',
-        'chat-welcome': 'Hi! Type "Contact" to message us!', 'chat-placeholder': 'Type here...',
-        'modal-title': 'Confirm?', 'modal-desc': 'Clear all messages?', 'btn-confirm': 'Delete', 'btn-cancel': 'Cancel',
-        'footer-copy': '© 2026 Group 33. All rights reserved.',
-        'footer-data': 'Data Policy', 'footer-access': 'Accessibility', 'footer-contact': 'Contact Us',
+        'chat-header': 'Circle AI Tutor',
+        'ai-name': 'AI:',
+        'chat-welcome': 'Hi! Type "Contact" to message us!',
+        'chat-placeholder': 'Type here...',
+        'modal-title': 'Confirm?',
+        'modal-desc': 'Clear all messages?',
+        'btn-confirm': 'Delete',
+        'btn-cancel': 'Cancel',
+        'footer-copy': '© 2026 25/26_EBU5315_G19. All rights reserved.',
+        'footer-data': 'Data Policy',
+        'footer-access': 'Accessibility',
+        'footer-contact': 'Contact Us',
         'zu-name': 'Zu Chongzhi',
         'arch-name': 'Archimedes',
+        'theme-dark': 'Dark Mode',
+        'theme-light': 'Light Mode',
+        'audio-on': 'Sound On',
+        'audio-off': 'Sound Off',
+        'nav-toggle-label': 'Menu',
+        'modal-close': 'OK',
+        'definition-title': 'Definition',
+        'takeaways-title': 'Key Takeaways',
+        'chat-reply-contact': 'You can contact our teammate at 2024213571@bupt.cn.',
+        'chat-reply-default': 'Ask about a theorem, open a gallery card, or use the footer links for policies and contact details.'
     },
-    'zh': {
-        // 顶部与无障碍
-        'btn-lang': '中 / EN', 'btn-contrast': '👁️ 对比度', 'btn-theme': '🌙 黑夜模式', 'btn-sound': '声音',
-        // 导航
-        'logo-text': '圆几何大师', 'nav-home': '首页', 'nav-game': '数学游戏', 'nav-quiz': '互动测验',
-        'bc-home': '首页', 'bc-gallery': '定理库',
-        // 主页 Hero
+    zh: {
+        'btn-lang': '中 / EN',
+        'btn-contrast': '对比度',
+        'logo-text': '圆几何大师',
+        'nav-home': '首页',
+        'nav-game': '游戏',
+        'nav-quiz': '测验',
+        'bc-home': '首页',
+        'bc-gallery': '定理库',
+        'bc-current-home': '总览',
         'hero-title': '精通圆几何 <br><span class="highlight">由 AI 驱动教学</span>',
-        'hero-usp': '互动动画、AI 引导辅导以及针对 GCSE 的练习。',
-        // 学习中心卡片
+        'hero-usp': '互动动画、AI 引导辅导以及练习整合在同一站点中。',
         'hub-title': '互动几何定理库',
-        'rule1-title': '切线-半径定理', 'rule1-desc': '切线在接触点垂直于圆的半径。',
-        'rule2-title': '圆心角定理', 'rule2-desc': '圆心角是同弧所对圆周角的两倍。',
-        'rule3-title': '内接四边形', 'rule3-desc': '圆内接四边形的对角之和为 180 度。',
-        'rule4-title': '弦切角定理', 'rule4-desc': '弦切角等于它所夹的弧所对的圆周角。',
-        'rule5-title': '同弧圆周角', 'rule5-desc': '同弧所对的所有圆周角都相等。',
-        'rule6-title': '半圆圆周角', 'rule6-desc': '直径（或半圆）所对的圆周角恒为 90 度。',
+        'rule1-title': '切线-半径定理',
+        'rule1-desc': '切线在接触点垂直于圆的半径。',
+        'rule2-title': '圆心角定理',
+        'rule2-desc': '圆心角是同弧所对圆周角的两倍。',
+        'rule3-title': '内接四边形',
+        'rule3-desc': '圆内接四边形的对角之和为 180 度。',
+        'rule4-title': '弦切角定理',
+        'rule4-desc': '弦切角等于对应弧上的圆周角。',
+        'rule5-title': '同弧圆周角',
+        'rule5-desc': '同一段弧所对的圆周角都相等。',
+        'rule6-title': '半圆圆周角',
+        'rule6-desc': '半圆所对的圆周角始终为 90 度。',
         'btn-learn': '查看详情',
-        // 详情页/手风琴内部
-        'detail-explanation-title': '几何原理解析',
-        'side-tips': '核心要点',
-        'btn-back': '返回主页',
-        // 文化板块
+        'btn-back': '← 返回主页',
         'culture-label': '伟大数学家',
-        'meta-nation': '国籍', 'meta-era': '生卒/时代', 'meta-intro': '简介',
-        'val-cn': '中国古代', 'val-gr': '古希腊',
-        'culture-zh': '祖冲之将圆周率精确到小数点后七位，该纪录领先世界一千年。',
-        'culture-gr': '阿基米德利用割圆术研究 π，奠定了西方几何学的基础。',
-        // 广告与 Pro
+        'meta-nation': '国籍',
+        'meta-era': '时代',
+        'meta-intro': '简介',
+        'val-cn': '中国古代',
+        'val-gr': '古希腊',
+        'culture-zh': '祖冲之是著名的数学家和天文学家，他将圆周率精确到小数点后七位，该纪录保持了一千多年。',
+        'culture-gr': '阿基米德被认为是最伟大的数学家之一，他利用穷竭法逼近圆周率，并奠定了几何学基础。',
         'pro-title': '升级至 CircleMaster Pro',
-        'pro-desc': '获取无限次互动练习和 AI 知识点总结。',
+        'pro-desc': '获取无限次练习和 AI 知识点总结。',
         'pro-btn': '立即加入',
-        // AI 聊天与弹窗
-        'chat-header': 'AI 几何导师', 'ai-name': '助理: ',
-        'chat-welcome': '你好！输入“联系”向我们发消息！', 'chat-placeholder': '在此输入...',
-        'modal-title': '确认清空？', 'modal-desc': '确定删除聊天记录吗？', 'btn-confirm': '删除', 'btn-cancel': '取消',
-        'footer-copy': '© 2026 第33组。保留所有权利。',
-        'footer-data': '隐私政策', 'footer-access': '无障碍辅助', 'footer-contact': '联系我们',
+        'chat-header': 'AI 几何导师',
+        'ai-name': '助理:',
+        'chat-welcome': '你好！输入“联系”即可向我们留言。',
+        'chat-placeholder': '在这里输入...',
+        'modal-title': '确认清空？',
+        'modal-desc': '确定删除所有消息吗？',
+        'btn-confirm': '删除',
+        'btn-cancel': '取消',
+        'footer-copy': '© 2026 25/26_EBU5315_G19. 保留所有权利。',
+        'footer-data': '数据政策',
+        'footer-access': '无障碍说明',
+        'footer-contact': '联系我们',
         'zu-name': '祖冲之',
-        'arch-name': '阿基米德'
+        'arch-name': '阿基米德',
+        'theme-dark': '黑夜模式',
+        'theme-light': '明亮模式',
+        'audio-on': '声音开启',
+        'audio-off': '声音关闭',
+        'nav-toggle-label': '菜单',
+        'modal-close': '确定',
+        'definition-title': '几何定义',
+        'takeaways-title': '核心要点',
+        'chat-reply-contact': '你可以通过 2024213571@bupt.cn 联系我们的成员。',
+        'chat-reply-default': '你可以询问定理、打开卡片查看详情，或通过页脚链接查看政策与联系方式。'
     }
 };
 
-let currentLang = 'en';
-
-// --- 2. 定理内容数据库 ---
-// 1. 包含 6 个定理的完整数据库（自带 SVG 绘图）
 const theoremData = {
-     'tangent': {
-        titleEn: 'Tangent-Radius Theorem', titleZh: '切线-半径定理',
+    tangent: {
+        titleEn: 'Tangent-Radius Theorem',
+        titleZh: '切线-半径定理',
         descEn: 'A tangent is perpendicular to the radius at the point of contact.',
         descZh: '切线在接触点垂直于圆的半径。',
-        propsEn: ['Radius ⊥ Tangent', '90° Angle'], propsZh: ['半径垂直于切线', '夹角恒为 90°'],
-        svg: `<svg viewBox="0 0 200 200">
-            <circle cx="100" cy="80" r="60" stroke="currentColor" fill="none" stroke-width="2"/>
-            <line x1="100" y1="80" x2="100" y2="140" stroke="#007bff" stroke-width="3"/>
-            <line x1="40" y1="140" x2="160" y2="140" stroke="#ff4757" stroke-width="3"/>
-            <rect x="100" y="130" width="10" height="10" fill="none" stroke="#ff4757"/>
-            <circle cx="100" cy="80" r="3" fill="currentColor"/>
-            <text x="105" y="110" font-size="12" fill="#007bff">Radius</text>
-            <text x="140" y="155" font-size="12" fill="#ff4757">Tangent</text>
-        </svg>`
+        propsEn: ['Radius perpendicular to tangent', 'Right angle at contact point'],
+        propsZh: ['半径垂直于切线', '接触点形成直角'],
+        svg: `<svg viewBox="0 0 200 200"><circle cx="100" cy="80" r="60" stroke="currentColor" fill="none" stroke-width="2"></circle><line x1="100" y1="80" x2="100" y2="140" stroke="#3a7bd5" stroke-width="3"></line><line x1="40" y1="140" x2="160" y2="140" stroke="#ef6b6b" stroke-width="3"></line><rect x="100" y="130" width="10" height="10" fill="none" stroke="#ef6b6b"></rect><circle cx="100" cy="80" r="3" fill="currentColor"></circle></svg>`
     },
     'center-angle': {
-        titleEn: 'Angle at Center', titleZh: '圆心角定理',
-        descEn: 'The angle at the center is exactly twice the angle at the circumference.',
-        descZh: '圆心角的大小正好是同弧所对圆周角的两倍。',
-        propsEn: ['Center = 2θ', 'Circumference = θ'], propsZh: ['圆心角 = 2倍圆周角', '对应同一段弧'],
-        svg: `<svg viewBox="0 0 200 200">
-            <circle cx="100" cy="100" r="70" stroke="currentColor" fill="none" stroke-width="2"/>
-            <path d="M40 140 L100 100 L160 140" stroke="#007bff" fill="none" stroke-width="2.5"/>
-            <path d="M40 140 L100 35 L160 140" stroke="#ff4757" fill="none" stroke-width="2.5"/>
-            <circle cx="100" cy="100" r="3" fill="currentColor"/>
-            <text x="92" y="125" font-size="14" fill="#007bff" font-weight="bold">2θ</text>
-            <text x="95" y="60" font-size="14" fill="#ff4757" font-weight="bold">θ</text>
-        </svg>`
+        titleEn: 'Angle at Center',
+        titleZh: '圆心角定理',
+        descEn: 'The angle at the center is exactly twice the angle at the circumference on the same arc.',
+        descZh: '同弧所对的圆心角正好是圆周角的两倍。',
+        propsEn: ['Center angle = 2 x inscribed angle', 'Both angles stand on the same arc'],
+        propsZh: ['圆心角 = 2 倍圆周角', '两个角对应同一段弧'],
+        svg: `<svg viewBox="0 0 200 200"><circle cx="100" cy="100" r="70" stroke="currentColor" fill="none" stroke-width="2"></circle><path d="M40 140 L100 100 L160 140" stroke="#3a7bd5" fill="none" stroke-width="2.5"></path><path d="M40 140 L100 35 L160 140" stroke="#ef6b6b" fill="none" stroke-width="2.5"></path><circle cx="100" cy="100" r="3" fill="currentColor"></circle><text x="92" y="125" font-size="14" fill="#3a7bd5" font-weight="bold">2θ</text><text x="95" y="60" font-size="14" fill="#ef6b6b" font-weight="bold">θ</text></svg>`
     },
-    'cyclic': {
-        titleEn: 'Cyclic Quadrilaterals', titleZh: '圆内接四边形',
-        descEn: 'Opposite angles of a quadrilateral inscribed in a circle sum to 180°.',
-        descZh: '内接四边形的一组对角相加等于 180 度。',
-        propsEn: ['∠A + ∠C = 180°', 'Inscribed vertices'], propsZh: ['对角互补', '四个顶点均在圆上'],
-        svg: `<svg viewBox="0 0 200 200">
-            <circle cx="100" cy="100" r="75" stroke="currentColor" fill="none" stroke-width="2"/>
-            <path d="M70 30 L170 80 L130 170 L35 140 Z" stroke="#007bff" fill="#007bff" fill-opacity="0.1" stroke-width="2"/>
-            <text x="65" y="45" font-size="12" font-weight="bold" fill="currentColor">A</text>
-            <text x="115" y="160" font-size="12" font-weight="bold" fill="currentColor">C</text>
-            <text x="70" y="190" font-size="11" fill="#007bff">A + C = 180°</text>
-        </svg>`
+    cyclic: {
+        titleEn: 'Cyclic Quadrilaterals',
+        titleZh: '圆内接四边形',
+        descEn: 'Opposite angles of a quadrilateral inscribed in a circle add up to 180 degrees.',
+        descZh: '圆内接四边形的一组对角相加等于 180 度。',
+        propsEn: ['Opposite angles are supplementary', 'All four vertices lie on the circle'],
+        propsZh: ['对角互补', '四个顶点都在圆上'],
+        svg: `<svg viewBox="0 0 200 200"><circle cx="100" cy="100" r="75" stroke="currentColor" fill="none" stroke-width="2"></circle><path d="M70 30 L170 80 L130 170 L35 140 Z" stroke="#3a7bd5" fill="#3a7bd5" fill-opacity="0.1" stroke-width="2"></path><text x="70" y="190" font-size="11" fill="#3a7bd5">A + C = 180°</text></svg>`
     },
-    'alternate': {
-        titleEn: 'Alternate Segment', titleZh: '弦切角定理',
-        descEn: 'The angle between tangent and chord equals the angle in the alternate segment.',
-        descZh: '弦切角等于它所夹的弧所对的圆周角。',
-        propsEn: ['∠x = ∠y', 'Tangent & Chord'], propsZh: ['弦切角相等', '涉及切线与内接三角形'],
-        svg: `<svg viewBox="0 0 200 200">
-            <circle cx="100" cy="85" r="65" stroke="currentColor" fill="none" stroke-width="2"/>
-            <path d="M100 150 L165 85 L45 60 Z" stroke="#007bff" fill="none" stroke-width="2"/>
-            <line x1="40" y1="150" x2="160" y2="150" stroke="#ff4757" stroke-width="3"/>
-            <path d="M100 150 L115 150 A 15 15 0 0 0 110 140" fill="none" stroke="#ff4757" stroke-width="2"/>
-            <text x="115" y="145" font-size="14" fill="#ff4757">y</text>
-            <text x="45" y="80" font-size="14" fill="#007bff">x</text>
-            <text x="75" y="185" font-size="11" fill="currentColor">Angle y = Angle x</text>
-        </svg>`
+    alternate: {
+        titleEn: 'Alternate Segment',
+        titleZh: '弦切角定理',
+        descEn: 'The angle between a tangent and a chord equals the angle in the alternate segment.',
+        descZh: '切线与弦所形成的角，等于对侧圆周角。',
+        propsEn: ['Tangent-chord angle equals inscribed angle', 'Same intercepted arc'],
+        propsZh: ['弦切角等于圆周角', '对应同一段弧'],
+        svg: `<svg viewBox="0 0 200 200"><circle cx="100" cy="85" r="65" stroke="currentColor" fill="none" stroke-width="2"></circle><path d="M100 150 L165 85 L45 60 Z" stroke="#3a7bd5" fill="none" stroke-width="2"></path><line x1="40" y1="150" x2="160" y2="150" stroke="#ef6b6b" stroke-width="3"></line><text x="75" y="185" font-size="11" fill="currentColor">x = y</text></svg>`
     },
     'same-arc': {
-        titleEn: 'Same Arc Theorem', titleZh: '同弧圆周角',
+        titleEn: 'Same Arc Theorem',
+        titleZh: '同弧圆周角',
         descEn: 'All angles subtended by the same arc at the circumference are equal.',
         descZh: '同一段弧所对应的所有圆周角大小都相等。',
-        propsEn: ['Constant Angle', 'Same Arc'], propsZh: ['角度相等', '对应同一段红色弧'],
-        svg: `<svg viewBox="0 0 200 200">
-            <circle cx="100" cy="100" r="75" stroke="currentColor" fill="none" stroke-width="2"/>
-            <path d="M40 80 L100 175 L160 80" stroke="#007bff" fill="none" stroke-width="2" opacity="0.4"/>
-            <path d="M40 80 L100 25 L160 80" stroke="#007bff" fill="none" stroke-width="2"/>
-            <text x="95" y="50" font-size="14" fill="#007bff">α</text>
-            <text x="95" y="160" font-size="14" fill="#007bff" opacity="0.6">α</text>
-            <path d="M40 80 A 75 75 0 0 0 160 80" stroke="#ff4757" stroke-width="4" fill="none"/>
-        </svg>`
+        propsEn: ['Angles on the same arc are equal', 'Arc AB stays fixed'],
+        propsZh: ['同弧所对角相等', '弧 AB 固定不变'],
+        svg: `<svg viewBox="0 0 200 200"><circle cx="100" cy="100" r="75" stroke="currentColor" fill="none" stroke-width="2"></circle><path d="M40 80 L100 175 L160 80" stroke="#3a7bd5" fill="none" stroke-width="2" opacity="0.4"></path><path d="M40 80 L100 25 L160 80" stroke="#3a7bd5" fill="none" stroke-width="2"></path><text x="95" y="50" font-size="14" fill="#3a7bd5">α</text><text x="95" y="160" font-size="14" fill="#3a7bd5" opacity="0.6">α</text><path d="M40 80 A 75 75 0 0 0 160 80" stroke="#ef6b6b" stroke-width="4" fill="none"></path></svg>`
     },
-    'semicircle': {
-        titleEn: 'Semi-circle Angle', titleZh: '半圆圆周角',
-        descEn: 'The angle inscribed in a semi-circle is always 90°.',
-        descZh: '半圆（或直径）所对应的圆周角永远是 90 度。',
-        propsEn: ['Diameter as base', 'Right angle'], propsZh: ['直径为底边', '始终是直角'],
-        svg: `<svg viewBox="0 0 200 200">
-            <path d="M25 100 A 75 75 0 1 1 175 100" stroke="currentColor" fill="none" stroke-dasharray="3"/>
-            <path d="M25 100 A 75 75 0 0 1 175 100" stroke="currentColor" fill="none" stroke-width="2"/>
-            <line x1="25" y1="100" x2="175" y2="100" stroke="currentColor" stroke-width="2"/>
-            <path d="M25 100 L100 25 L175 100" stroke="#007bff" fill="none" stroke-width="2.5"/>
-            <rect x="95" y="25" width="10" height="10" fill="none" stroke="#ff4757" transform="rotate(45 100 25)"/>
-            <text x="90" y="55" font-size="12" fill="#ff4757" font-weight="bold">90°</text>
-            <circle cx="100" cy="100" r="3" fill="currentColor"/>
-        </svg>`
+    semicircle: {
+        titleEn: 'Semi-circle Angle',
+        titleZh: '半圆圆周角',
+        descEn: 'The angle subtended by a diameter is always 90 degrees.',
+        descZh: '直径所对的圆周角永远是 90 度。',
+        propsEn: ['Diameter as base', 'Angle is always 90 degrees'],
+        propsZh: ['直径作为底边', '角度始终为 90 度'],
+        svg: `<svg viewBox="0 0 200 200"><path d="M25 100 A 75 75 0 0 1 175 100" stroke="currentColor" fill="none" stroke-width="2"></path><line x1="25" y1="100" x2="175" y2="100" stroke="currentColor" stroke-width="2"></line><path d="M25 100 L100 25 L175 100" stroke="#3a7bd5" fill="none" stroke-width="2.5"></path><text x="90" y="55" font-size="12" fill="#ef6b6b" font-weight="bold">90°</text></svg>`
     }
 };
 
-// --- 3. 核心功能函数 ---
-function changeLanguage() {
-    currentLang = currentLang === 'en' ? 'zh' : 'en';
+const state = {
+    currentLang: 'en',
+    soundEnabled: true,
+    currentDetailId: null,
+    openAccordionId: null
+};
 
-    // 1. 翻译所有带有 data-i18n 的静态标签
-    document.querySelectorAll('[data-i18n]').forEach(el => {
-        const key = el.getAttribute('data-i18n');
-        if (translations[currentLang][key]) el.innerHTML = translations[currentLang][key];
-    });
+const mainView = document.getElementById('main-view');
+const detailView = document.getElementById('detail-view');
+const accordionContainer = document.getElementById('theorems-accordion-container');
+const activeTheoremName = document.getElementById('active-theorem-name');
+const themeBtn = document.getElementById('theme-btn');
+const audioBtn = document.getElementById('audio-btn');
+const chatWidget = document.getElementById('ai-chat-widget');
+const chatBody = document.getElementById('chat-body');
+const chatInput = document.getElementById('chat-input');
+const confirmModal = document.getElementById('confirm-modal');
+const privacyModal = document.getElementById('privacy-modal');
+const privacyBody = document.getElementById('privacy-body');
 
-    // 2. 翻译输入框占位符
-    document.getElementById('chat-input').placeholder = translations[currentLang]['chat-placeholder'];
-
-    // 3. 【新增】如果正在详情页，同步翻译面包屑和手风琴内容
-    if (document.getElementById('detail-view').style.display === 'block') {
-        renderTheorems(); // 重新渲染列表以更新语言
-
-        // 找到当前打开的那个项的 ID
-        const activeItem = document.querySelector('.accordion-item.active');
-        if (activeItem) {
-            const id = activeItem.id.replace('acc-', '');
-            const isEn = (currentLang === 'en');
-            // 更新面包屑里的名字
-            document.getElementById('active-theorem-name').innerText = isEn ? theoremData[id].titleEn : theoremData[id].titleZh;
-            // 重新展开它
-            toggleAccordion(id);
-        }
-    }
+function t(key) {
+    return translations[state.currentLang][key] || translations.en[key] || key;
 }
 
-// 1. 核心：点击首页卡片进入详情页
-function goToDetail(id) {
-    document.getElementById('main-view').style.display = 'none';
-    document.getElementById('detail-view').style.display = 'block';
-
-    const isEn = (currentLang === 'en');
-    // 初始化面包屑里的定理名字
-    document.getElementById('active-theorem-name').innerText = isEn ? theoremData[id].titleEn : theoremData[id].titleZh;
-
-    renderTheorems();
-    setTimeout(() => {
-        toggleAccordion(id);
-    }, 50);
+function theoremTitle(id) {
+    const theorem = theoremData[id];
+    if (!theorem) return '';
+    return state.currentLang === 'zh' ? theorem.titleZh : theorem.titleEn;
 }
 
-// 2. 渲染手风琴列表
-function renderTheorems() {
-    const container = document.getElementById('theorems-accordion-container');
-    if (!container) return;
-
-    container.innerHTML = ''; // 清空旧内容
-
-    Object.keys(theoremData).forEach(key => {
-        const item = theoremData[key];
-        const isEn = (currentLang === 'en');
-        const title = isEn ? item.titleEn : item.titleZh;
-        const desc = isEn ? item.descEn : item.descZh;
-        const props = isEn ? item.propsEn : item.propsZh;
-
-        // ... 在 renderTheorems 函数内 ...
-const html = `
-    <div class="accordion-item" id="acc-${key}">
-        <div class="accordion-header" onclick="toggleAccordion('${key}')">
-            <span>${isEn ? item.titleEn : item.titleZh}</span>
-            <span class="arrow-icon">▼</span>
-        </div>
-        <div class="accordion-content">
-            <div class="demo-container">
-                ${item.svg}
-            </div>
-            <div class="info-container">
-                <h3 style="color:var(--primary-blue); margin-top:0;">${isEn ? 'Definition' : '几何定义'}</h3>
-                <p style="margin-bottom:15px; font-size:0.95rem;">${isEn ? item.descEn : item.descZh}</p>
-                <h3 style="color:var(--primary-blue);">${isEn ? 'Key Takeaways' : '核心要点'}</h3>
-                <div class="prop-list-pro">
-                    ${(isEn ? item.propsEn : item.propsZh).map(p => `<div class="property-item">✅ ${p}</div>`).join('')}
-                </div>
-            </div>
-        </div>
-    </div>
-`;
-        container.insertAdjacentHTML('beforeend', html);
-    });
-}
-
-// 展开/折叠逻辑 (修正 Iframe 加载)
-function toggleAccordion(key) {
-    const targetItem = document.getElementById(`acc-${key}`);
-    if (!targetItem) return;
-
-    const isAlreadyOpen = targetItem.classList.contains('active');
-
-    // 关闭所有并清除 iframe 释放内存
-    document.querySelectorAll('.accordion-item').forEach(item => {
-        item.classList.remove('active');
-        const box = item.querySelector('.demo-container');
-        if (box) box.innerHTML = '';
-    });
-
-    if (!isAlreadyOpen) {
-        targetItem.classList.add('active');
-        const box = document.getElementById(`iframe-box-${key}`);
-        if (box) {
-            // 添加 Loading 提示文字
-            box.innerHTML = '<div style="padding:20px; text-align:center;">Loading Geometry Interactive...</div>';
-
-            // 插入真正的 iframe
-            const iframe = document.createElement('iframe');
-            iframe.src = theoremData[key].url;
-            iframe.style.width = "100%";
-            iframe.style.height = "100%";
-            iframe.style.border = "none";
-            iframe.setAttribute('allowfullscreen', 'true');
-
-            box.innerHTML = ''; // 清除 loading
-            box.appendChild(iframe);
-        }
-
-        setTimeout(() => {
-            targetItem.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }, 100);
-    }
-}
-
-// 返回主页
-function hideDetail() {
-    document.getElementById('main-view').style.display = 'block';
-    document.getElementById('detail-view').style.display = 'none';
-    window.scrollTo(0, 0);
-}
-
-// 修改原有的返回函数
-function hideDetail() {
-    document.getElementById('main-view').style.display = 'block';
-    document.getElementById('detail-view').style.display = 'none';
-}
-
-function toggleContrast() {
-    const isHigh = document.documentElement.getAttribute('data-a11y') === 'high-contrast';
-    isHigh ? document.documentElement.removeAttribute('data-a11y') : document.documentElement.setAttribute('data-a11y', 'high-contrast');
-}
-
-function toggleSound() {
-    const icon = document.getElementById('sound-icon');
-    icon.innerText = (icon.innerText === "🔊") ? "🔇" : "🔊";
-}
-
-function toggleChat() {
-    const chat = document.getElementById('ai-chat-widget');
-    chat.style.display = (chat.style.display === 'none') ? 'block' : 'none';
-}
-
-// 暗黑模式切换
-document.getElementById('theme-btn').onclick = function() {
+function updateThemeButton() {
     const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-    const newTheme = isDark ? 'light' : 'dark';
-    document.documentElement.setAttribute('data-theme', newTheme);
-    this.innerText = newTheme === 'dark' ? "☀️ Light Mode" : translations[currentLang]['btn-theme'];
-};
+    const themeIcon = document.getElementById('theme-icon');
+    const themeLabel = document.getElementById('theme-label');
 
-function adjustFontSize(d) {
-    const root = document.documentElement;
-    let size = parseInt(window.getComputedStyle(root).getPropertyValue('--font-size-base')) || 16;
-    size = Math.min(Math.max(size + (d * 2), 12), 26);
-    root.style.setProperty('--font-size-base', size + 'px');
-}
-
-// 切换隐私政策模态框
-function togglePrivacyModal(show) {
-    const modal = document.getElementById('privacy-modal');
-    if (show) {
-        // 自动根据当前语言显示内容 (假设你的语言变量是 currentLang)
-        const isZh = (typeof currentLang !== 'undefined' && currentLang === 'zh');
-        document.querySelector('.lang-en').style.display = isZh ? 'none' : 'block';
-        document.querySelector('.lang-zh').style.display = isZh ? 'block' : 'none';
-
-        modal.style.display = 'flex';
-        document.body.style.overflow = 'hidden'; // 禁止背景滚动
-    } else {
-        modal.style.display = 'none';
-        document.body.style.overflow = 'auto';
+    if (themeIcon) {
+        themeIcon.textContent = isDark ? '☀️' : '🌙';
+    }
+    if (themeLabel) {
+        themeLabel.textContent = isDark ? t('theme-light') : t('theme-dark');
     }
 }
 
-// 触发 AI 清空确认 (绑定到垃圾桶图标)
-function showClearChatConfirm() {
-    document.getElementById('confirm-modal').style.display = 'flex';
-}
+function updateAudioButton() {
+    const audioIcon = document.getElementById('audio-icon');
+    const audioLabel = document.getElementById('audio-label');
 
-function toggleConfirmModal(show) {
-    document.getElementById('confirm-modal').style.display = show ? 'flex' : 'none';
-}
-
-// 真正执行清空
-function executeClearChat() {
-    const chatBody = document.querySelector('.chat-body');
-    if (chatBody) {
-        chatBody.innerHTML = ''; // 清空内容
-        // 发送一条 AI 初始欢迎语
-        const welcome = (typeof currentLang !== 'undefined' && currentLang === 'zh')
-            ? "AI: 历史记录已清空。"
-            : "AI: Chat history cleared.";
-        chatBody.innerHTML = `<p>${welcome}</p>`;
+    if (audioIcon) {
+        audioIcon.textContent = state.soundEnabled ? '🔊' : '🔇';
     }
-    toggleConfirmModal(false);
+    if (audioLabel) {
+        audioLabel.textContent = state.soundEnabled ? t('audio-on') : t('audio-off');
+    }
 }
 
-function confirmClearChat() { document.getElementById('confirm-modal').style.display = 'flex'; }
-function closeModal() { document.getElementById('confirm-modal').style.display = 'none'; }
-function executeClear() { document.getElementById('chat-body').innerHTML = ""; closeModal(); }
+function syncBodyLock() {
+    const hasOpenModal = (confirmModal && !confirmModal.hidden) || (privacyModal && !privacyModal.hidden);
+    document.body.style.overflow = hasOpenModal ? 'hidden' : '';
+}
+
+function setNavOpen(isOpen) {
+    const navToggle = document.querySelector('[data-nav-toggle]');
+    const siteNav = document.querySelector('[data-site-nav]');
+    if (!navToggle || !siteNav) return;
+
+    siteNav.classList.toggle('is-open', isOpen);
+    navToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+}
 
 function renderTheorems() {
-    const container = document.getElementById('theorems-accordion-container');
-    container.innerHTML = '';
+    if (!accordionContainer) return;
 
-    Object.keys(theoremData).forEach(key => {
-        const item = theoremData[key];
-        const isEn = (currentLang === 'en');
-        const html = `
-            <div class="accordion-item" id="acc-${key}">
+    accordionContainer.innerHTML = Object.entries(theoremData).map(([key, item]) => {
+        const title = state.currentLang === 'zh' ? item.titleZh : item.titleEn;
+        const desc = state.currentLang === 'zh' ? item.descZh : item.descEn;
+        const props = state.currentLang === 'zh' ? item.propsZh : item.propsEn;
+        const isOpen = state.openAccordionId === key;
+
+        return `
+            <div class="accordion-item${isOpen ? ' active' : ''}" id="acc-${key}">
                 <div class="accordion-header" onclick="toggleAccordion('${key}')">
-                    <span>${isEn ? item.titleEn : item.titleZh}</span>
-                    <span>▼</span>
+                    <span>${title}</span>
+                    <span class="arrow-icon">▼</span>
                 </div>
                 <div class="accordion-content">
                     <div class="demo-container">
                         ${item.svg}
                     </div>
                     <div class="info-container">
-                        <h3 style="color:var(--primary-blue)">${isEn ? 'Definition' : '几何定义'}</h3>
-                        <p>${isEn ? item.descEn : item.descZh}</p>
-                        <h3 style="color:var(--primary-blue); margin-top:20px;">${isEn ? 'Key Takeaways' : '核心要点'}</h3>
+                        <h3>${t('definition-title')}</h3>
+                        <p>${desc}</p>
+                        <h3>${t('takeaways-title')}</h3>
                         <div class="prop-list-pro">
-                            ${(isEn ? item.propsEn : item.propsZh).map(p => `<div class="property-item">✅ ${p}</div>`).join('')}
+                            ${props.map((prop) => `<div class="property-item">${prop}</div>`).join('')}
                         </div>
                     </div>
                 </div>
             </div>
         `;
-        container.insertAdjacentHTML('beforeend', html);
-    });
+    }).join('');
 }
 
-function toggleAccordion(key) {
-    const targetItem = document.getElementById(`acc-${key}`);
-    const isAlreadyOpen = targetItem.classList.contains('active');
-    document.querySelectorAll('.accordion-item').forEach(item => item.classList.remove('active'));
-    if (!isAlreadyOpen) {
-        targetItem.classList.add('active');
-        setTimeout(() => targetItem.scrollIntoView({ behavior: 'smooth', block: 'start' }), 100);
+function applyTranslations() {
+    document.documentElement.lang = state.currentLang;
+
+    document.querySelectorAll('[data-i18n]').forEach((node) => {
+        const key = node.getAttribute('data-i18n');
+        node.innerHTML = t(key);
+    });
+
+    const navToggleLabel = document.querySelector('[data-nav-toggle-label]');
+    if (navToggleLabel) {
+        navToggleLabel.textContent = t('nav-toggle-label');
     }
+
+    const privacyCloseButton = document.querySelector('#privacy-modal .modal-close-btn');
+    if (privacyCloseButton) {
+        privacyCloseButton.textContent = t('modal-close');
+    }
+
+    if (chatInput) {
+        chatInput.placeholder = t('chat-placeholder');
+    }
+
+    updateThemeButton();
+    updateAudioButton();
+
+    if (state.currentDetailId && activeTheoremName) {
+        activeTheoremName.textContent = theoremTitle(state.currentDetailId);
+    }
+
+    if (detailView && !detailView.hidden) {
+        renderTheorems();
+    }
+}
+
+function changeLanguage() {
+    state.currentLang = state.currentLang === 'en' ? 'zh' : 'en';
+    applyTranslations();
 }
 
 function goToDetail(id) {
-    document.getElementById('main-view').style.display = 'none';
-    document.getElementById('detail-view').style.display = 'block';
+    state.currentDetailId = id;
+    state.openAccordionId = id;
+
+    if (mainView) {
+        mainView.hidden = true;
+    }
+    if (detailView) {
+        detailView.hidden = false;
+    }
+    if (activeTheoremName) {
+        activeTheoremName.textContent = theoremTitle(id);
+    }
+
     renderTheorems();
-    setTimeout(() => toggleAccordion(id), 50);
+    setNavOpen(false);
 }
 
 function hideDetail() {
-    document.getElementById('main-view').style.display = 'block';
-    document.getElementById('detail-view').style.display = 'none';
-    window.scrollTo(0, 0);
+    state.currentDetailId = null;
+    state.openAccordionId = null;
+
+    if (mainView) {
+        mainView.hidden = false;
+    }
+    if (detailView) {
+        detailView.hidden = true;
+    }
+
+    window.scrollTo({ top: 0, behavior: 'smooth' });
 }
-/* =========================================
-   Version 4 核心逻辑：隐私政策、二次确认、AI 交互
-   ========================================= */
 
-// 1. 隐私政策模态框逻辑 (对应评分标准：Ethical & Transparent Data Policy)
-function togglePrivacyModal(show) {
-    const modal = document.getElementById('privacy-modal');
-    const body = document.getElementById('privacy-body');
-    if (!modal || !body) return;
+function toggleAccordion(id) {
+    state.openAccordionId = state.openAccordionId === id ? null : id;
+    renderTheorems();
 
-    if (show) {
-        const isZh = (currentLang === 'zh');
-        // 动态生成内容，确保语言同步
-        body.innerHTML = isZh ? `
-            <h2 style="color:var(--primary-blue); margin-bottom:15px;">数据隐私政策</h2>
-            <p>本网站 CircleMaster 仅用于教学演示。我们承诺：</p>
-            <ul style="padding-left:20px; line-height:1.8;">
-                <li><strong>数据安全：</strong> AI 对话为实时处理，不会在服务器上进行存储或记录。</li>
-                <li><strong>个人隐私：</strong> 我们不会收集、销售或共享任何用户个人信息。</li>
-                <li><strong>Cookies：</strong> 我们仅使用本地存储记录您的无障碍偏好（如暗黑模式）。</li>
-                <li><strong>合规联系：</strong> 2024213574@bupt.cn</li>
-            </ul>
-        ` : `
-            <h2 style="color:var(--primary-blue); margin-bottom:15px;">Data Privacy Policy</h2>
-            <p>CircleMaster is for educational purposes only. We promise:</p>
-            <ul style="padding-left:20px; line-height:1.8;">
-                <li><strong>AI Security:</strong> Conversations are processed real-time and NOT stored.</li>
-                <li><strong>Privacy:</strong> We do not collect, sell, or share any personal data.</li>
-                <li><strong>Cookies:</strong> We only use local storage to save your theme preferences.</li>
-                <li><strong>Accountability:</strong> 2024213574@bupt.cn</li>
-            </ul>
-        `;
-        modal.style.display = 'flex';
-        document.body.style.overflow = 'hidden'; // 弹窗时锁定背景滚动
-    } else {
-        modal.style.display = 'none';
-        document.body.style.overflow = 'auto'; // 恢复滚动
+    if (state.openAccordionId) {
+        const activeItem = document.getElementById(`acc-${id}`);
+        if (activeItem) {
+            setTimeout(() => {
+                activeItem.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }, 50);
+        }
     }
 }
 
-// 2. AI 聊天清空二次确认逻辑 (对应评分标准：Tolerance & Safety)
+function toggleContrast() {
+    const isHighContrast = document.documentElement.getAttribute('data-a11y') === 'high-contrast';
+    if (isHighContrast) {
+        document.documentElement.removeAttribute('data-a11y');
+    } else {
+        document.documentElement.setAttribute('data-a11y', 'high-contrast');
+    }
+}
+
+function toggleTheme() {
+    const currentTheme = document.documentElement.getAttribute('data-theme');
+    document.documentElement.setAttribute('data-theme', currentTheme === 'dark' ? 'light' : 'dark');
+    updateThemeButton();
+}
+
+function adjustFontSize(delta) {
+    const root = document.documentElement;
+    let size = parseInt(window.getComputedStyle(root).getPropertyValue('--font-size-base'), 10) || 16;
+    size = Math.min(Math.max(size + (delta * 2), 12), 26);
+    root.style.setProperty('--font-size-base', `${size}px`);
+}
+
+function toggleSound() {
+    state.soundEnabled = !state.soundEnabled;
+    updateAudioButton();
+}
+
+function toggleChat() {
+    if (!chatWidget) return;
+    chatWidget.hidden = !chatWidget.hidden;
+}
+
 function confirmClearChat() {
-    const modal = document.getElementById('confirm-modal');
-    if (modal) modal.style.display = 'flex';
+    if (!confirmModal) return;
+    confirmModal.hidden = false;
+    syncBodyLock();
 }
 
 function closeModal() {
-    const modal = document.getElementById('confirm-modal');
-    if (modal) modal.style.display = 'none';
+    if (!confirmModal) return;
+    confirmModal.hidden = true;
+    syncBodyLock();
 }
 
 function executeClear() {
-    const chatBody = document.getElementById('chat-body');
     if (chatBody) {
-        // 清空内容并保留一个专业提示
-        const welcome = (currentLang === 'zh')
-            ? "<strong>AI:</strong> 对话记录已清空。您可以继续提问。"
-            : "<strong>AI:</strong> Chat history cleared. How can I help you again?";
-        chatBody.innerHTML = `<p>${welcome}</p>`;
+        chatBody.innerHTML = `<p><strong>${t('ai-name')}</strong> <span>${t('chat-welcome')}</span></p>`;
     }
     closeModal();
 }
 
-// 3. AI 关键词检测 (检测 "Contact" 或 "联系")
-const chatInputBox = document.getElementById('chat-input');
-if(chatInputBox) {
-    chatInputBox.addEventListener('keypress', function(e) {
-        if (e.key === 'Enter' && this.value.trim() !== "") {
-            const userInput = this.value.toLowerCase();
+function footerModalContent(type) {
+    if (state.currentLang === 'zh') {
+        if (type === 'data') {
+            return `
+                <h2>数据政策</h2>
+                <p>CircleMaster 仅用于教学演示。我们承诺以透明、最小化的方式处理站点偏好和交互内容。</p>
+                <ul>
+                    <li><strong>实时处理：</strong> 页面内 AI 提示和交互内容仅在当前浏览器会话中使用。</li>
+                    <li><strong>个人信息：</strong> 我们不会在站点中主动收集、出售或共享你的个人信息。</li>
+                    <li><strong>联系方式：</strong> 如需反馈，请发送邮件至 2024213571@bupt.cn。</li>
+                </ul>
+                <div class="preference-note"><strong>偏好说明：</strong> 主题、字体和无障碍设置由浏览器当前页面即时应用。</div>
+            `;
+        }
+        if (type === 'access') {
+            return `
+                <h2>无障碍说明</h2>
+                <p>我们希望 Home、Game、Quiz 三页都提供一致且可理解的学习体验。</p>
+                <ul>
+                    <li><strong>视觉支持：</strong> 支持黑夜模式、高对比度和字体缩放。</li>
+                    <li><strong>结构一致：</strong> 统一导航、面包屑和页脚，降低跨页切换成本。</li>
+                    <li><strong>持续改进：</strong> 如发现可读性或操作问题，欢迎联系团队反馈。</li>
+                </ul>
+            `;
+        }
+        return `
+            <h2>联系我们</h2>
+            <p>如果你对课程内容、设计实现或无障碍细节有建议，欢迎联系我们。</p>
+            <ul>
+                <li><strong>项目反馈：</strong> 可通过仓库 Issue 或邮件提交问题。</li>
+                <li><strong>响应方式：</strong> 我们会根据课程项目节奏尽快回复。</li>
+            </ul>
+        `;
+    }
 
-            // 如果输入包含关键词，在 0.6 秒后自动回复 BUPT 邮箱
-            if (userInput.includes('contact') || userInput.includes('联系')) {
-                setTimeout(() => {
-                    const reply = (currentLang === 'zh')
-                        ? "AI: 我们的首席设计师邮箱是 2024213574@bupt.cn"
-                        : "AI: You can contact our lead designer at 2024213574@bupt.cn";
+    if (type === 'data') {
+        return `
+            <h2>Data Policy</h2>
+            <p>CircleMaster is an educational prototype. We keep site messaging and preference handling simple and transparent.</p>
+            <ul>
+                <li><strong>Session-first behaviour:</strong> AI hints and page interactions stay within the current browser session.</li>
+                <li><strong>Personal data:</strong> We do not intentionally collect, sell, or share personal user data through this site.</li>
+                <li><strong>Contact:</strong> Reach the team at 2024213571@bupt.cn for questions or concerns.</li>
+            </ul>
+            <div class="preference-note"><strong>Preference note:</strong> Theme, font size, and accessibility controls apply directly in the browser for the current page.</div>
+        `;
+    }
+    if (type === 'access') {
+        return `
+            <h2>Accessibility Statement</h2>
+            <p>We aim to keep Home, Game, and Quiz visually consistent and easier to navigate for all learners.</p>
+            <ul>
+                <li><strong>Visual support:</strong> Dark mode, high contrast, and font scaling are available from the shared toolbar.</li>
+                <li><strong>Consistent structure:</strong> Navigation, breadcrumbs, and footer behaviour are aligned across pages.</li>
+                <li><strong>Feedback welcome:</strong> Please contact the team if a control is unclear or difficult to use.</li>
+            </ul>
+        `;
+    }
+    return `
+        <h2>Contact Us</h2>
+        <p>If you have feedback about the content, design, or accessibility details, please get in touch.</p>
+        <ul>
+            <li><strong>Project feedback:</strong> You can also raise an issue in the project repository.</li>
+            <li><strong>Response style:</strong> We will reply as quickly as the course project schedule allows.</li>
+        </ul>
+    `;
+}
 
-                    const p = document.createElement('p');
-                    p.innerHTML = `<span style="color:var(--primary-blue); font-weight:bold;">${reply}</span>`;
-                    document.getElementById('chat-body').appendChild(p);
+function openFooterModal(type) {
+    if (!privacyModal || !privacyBody) return;
+    privacyBody.innerHTML = footerModalContent(type);
+    privacyModal.hidden = false;
+    syncBodyLock();
+}
 
-                    // 自动滚动到底部
-                    const chatBody = document.getElementById('chat-body');
-                    chatBody.scrollTop = chatBody.scrollHeight;
-                }, 600);
-            }
+function togglePrivacyModal(show) {
+    if (!privacyModal) return;
+    privacyModal.hidden = !show;
+    syncBodyLock();
+}
+
+function appendChatLine(label, message) {
+    if (!chatBody) return;
+    const paragraph = document.createElement('p');
+    paragraph.innerHTML = `<strong>${label}</strong> ${message}`;
+    chatBody.appendChild(paragraph);
+    chatBody.scrollTop = chatBody.scrollHeight;
+}
+
+function chatReply(message) {
+    const normalized = message.toLowerCase();
+    if (normalized.includes('contact') || message.includes('联系')) {
+        return t('chat-reply-contact');
+    }
+    return t('chat-reply-default');
+}
+
+function setupChat() {
+    if (!chatInput) return;
+
+    chatInput.addEventListener('keydown', (event) => {
+        if (event.key !== 'Enter' || chatInput.value.trim() === '') {
+            return;
+        }
+
+        const message = chatInput.value.trim();
+        appendChatLine('You:', message);
+        chatInput.value = '';
+
+        setTimeout(() => {
+            appendChatLine(t('ai-name'), chatReply(message));
+        }, 250);
+    });
+}
+
+function setupNavToggle() {
+    const navToggle = document.querySelector('[data-nav-toggle]');
+    const siteNav = document.querySelector('[data-site-nav]');
+    if (!navToggle || !siteNav) return;
+
+    navToggle.addEventListener('click', () => {
+        const isOpen = !siteNav.classList.contains('is-open');
+        setNavOpen(isOpen);
+    });
+
+    siteNav.querySelectorAll('a').forEach((link) => {
+        link.addEventListener('click', () => setNavOpen(false));
+    });
+
+    window.addEventListener('resize', () => {
+        if (window.innerWidth > 760) {
+            setNavOpen(false);
         }
     });
 }
 
-function openFooterModal(type) {
-    const modal = document.getElementById('privacy-modal');
-    const body = document.getElementById('privacy-body');
-    if (!modal || !body) return;
-
-    const isZh = (currentLang === 'zh');
-
-    if (type === 'data') {
-        // 数据政策内容 (你之前的内容)
-        body.innerHTML = isZh ? `
-            <h2>数据隐私政策</h2>
-            <p>CircleMaster 仅用于教学演示。我们承诺：</p>
-            <ul>
-                <li><strong>数据安全：</strong> AI 对话实时处理，不存储。</li>
-                <li><strong>个人隐私：</strong> 不收集、不共享任何用户信息。</li>
-                <li><strong>联系邮箱：</strong> 2024213574@bupt.cn</li>
-            </ul>
-        ` : `
-            <h2>Data Privacy Policy</h2>
-            <p>CircleMaster is for educational purposes only. We promise:</p>
-            <ul>
-                <li><strong>AI Security:</strong> Conversations are processed real-time and NOT stored.</li>
-                <li><strong>Privacy:</strong> We do not collect or share any personal data.</li>
-                <li><strong>Accountability:</strong> 2024213574@bupt.cn</li>
-            </ul>
-        `;
-    } else if (type === 'access') {
-        // 无障碍说明 (对应评分标准：Inclusive Design)
-        body.innerHTML = isZh ? `
-            <h2>无障碍辅助说明</h2>
-            <p>我们致力于为所有人提供平等的学习机会：</p>
-            <ul>
-                <li><strong>视觉辅助：</strong> 支持黑夜模式与高对比度切换。</li>
-                <li><strong>个性化：</strong> 字体大小可自由调节。</li>
-                <li><strong>标准合规：</strong> 努力符合 Web 内容无障碍指南 (WCAG)。</li>
-            </ul>
-        ` : `
-            <h2>Accessibility Statement</h2>
-            <p>We are committed to inclusive learning for everyone:</p>
-            <ul>
-                <li><strong>Visual Aid:</strong> Supports Dark Mode and High Contrast toggles.</li>
-                <li><strong>Customization:</strong> Adjustable font sizes for clear reading.</li>
-                <li><strong>Compliance:</strong> Striving to meet WCAG accessibility standards.</li>
-            </ul>
-        `;
-    } else if (type === 'contact') {
-        // 联系我们 (对应评分标准：Ethical/Contact)
-        body.innerHTML = isZh ? `
-            <h2>联系我们</h2>
-            <p>如果您有任何疑问或反馈，请通过以下方式联系：</p>
-            <ul>
-                <li><strong>首席设计师邮箱：</strong> 2024213574@bupt.cn</li>
-                <li><strong>响应时间：</strong> 我们将在 24 小时内回复。</li>
-                <li><strong>GitHub：</strong> 欢迎在项目仓库提交 Issue。</li>
-            </ul>
-        ` : `
-            <h2>Contact Us</h2>
-            <p>For any inquiries or feedback, please reach out to us:</p>
-            <ul>
-                <li><strong>Lead Designer Email:</strong> 2024213574@bupt.cn</li>
-                <li><strong>Response Time:</strong> We will respond within 24 hours.</li>
-                <li><strong>GitHub:</strong> Feel free to raise an issue in our repository.</li>
-            </ul>
-        `;
-    }
-
-    modal.style.display = 'flex';
-    document.body.style.overflow = 'hidden';
+if (themeBtn) {
+    themeBtn.addEventListener('click', toggleTheme);
 }
 
-// 记得保留关闭函数
-function togglePrivacyModal(show) {
-    if (!show) {
-        document.getElementById('privacy-modal').style.display = 'none';
-        document.body.style.overflow = 'auto';
-    }
+if (audioBtn) {
+    audioBtn.addEventListener('click', toggleSound);
 }
+
+if (confirmModal) {
+    confirmModal.hidden = true;
+}
+if (privacyModal) {
+    privacyModal.hidden = true;
+}
+syncBodyLock();
+
+applyTranslations();
+setupNavToggle();
+setupChat();
+
+window.changeLanguage = changeLanguage;
+window.goToDetail = goToDetail;
+window.hideDetail = hideDetail;
+window.toggleAccordion = toggleAccordion;
+window.toggleContrast = toggleContrast;
+window.adjustFontSize = adjustFontSize;
+window.toggleChat = toggleChat;
+window.confirmClearChat = confirmClearChat;
+window.closeModal = closeModal;
+window.executeClear = executeClear;
+window.openFooterModal = openFooterModal;
+window.togglePrivacyModal = togglePrivacyModal;

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -1,102 +1,100 @@
-// js/quiz.js
-(function(){
+(function () {
     "use strict";
 
-    // ---------- 中英文题库 ----------
     const questionBank = {
         zh: {
             basic: [
-                { 
-                    question: "若圆的半径为 5，直径是多少？", 
+                {
+                    question: "若圆的半径为 5，直径是多少？",
                     answer: "10",
                     analysis: "直径 = 2 × 半径，所以 2 × 5 = 10。"
                 },
-                { 
-                    question: "半径为 7 的圆，周长约为？(π≈3.14)", 
+                {
+                    question: "半径为 7 的圆，周长约为？(π≈3.14)",
                     answer: "43.96",
                     analysis: "周长 = 2πr = 2 × 3.14 × 7 = 43.96"
                 },
-                { 
-                    question: "一个圆的直径是 12，半径是？", 
+                {
+                    question: "一个圆的直径是 12，半径是？",
                     answer: "6",
                     analysis: "半径 = 直径 ÷ 2 = 6"
                 },
-                { 
-                    question: "圆的半径是 3，面积是多少？(π≈3.14)", 
+                {
+                    question: "圆的半径是 3，面积是多少？(π≈3.14)",
                     answer: "28.26",
                     analysis: "面积 = πr² = 3.14 × 9 = 28.26"
                 },
-                { 
-                    question: "直径为 10 的圆，周长是多少？(π≈3.14)", 
+                {
+                    question: "直径为 10 的圆，周长是多少？(π≈3.14)",
                     answer: "31.4",
                     analysis: "周长 = πd = 3.14 × 10 = 31.4"
                 },
-                { 
-                    question: "半径为 2 的圆，直径是多少？", 
+                {
+                    question: "半径为 2 的圆，直径是多少？",
                     answer: "4",
                     analysis: "直径 = 2 × 半径 = 2 × 2 = 4"
                 }
             ],
             normal: [
-                { 
-                    question: "半径为 4 的圆面积是多少？(π≈3.14)", 
+                {
+                    question: "半径为 4 的圆面积是多少？(π≈3.14)",
                     answer: "50.24",
                     analysis: "面积 = πr² = 3.14 × 16 = 50.24"
                 },
-                { 
-                    question: "周长 31.4 的圆，半径大约是多少？(π≈3.14)", 
+                {
+                    question: "周长 31.4 的圆，半径大约是多少？(π≈3.14)",
                     answer: "5",
                     analysis: "C=2πr => 31.4=2×3.14×r => r=5"
                 },
-                { 
-                    question: "一个扇形圆心角90°，半径6，弧长是多少？(π≈3.14)", 
+                {
+                    question: "一个扇形圆心角90°，半径6，弧长是多少？(π≈3.14)",
                     answer: "9.42",
                     analysis: "弧长 = (90/360)×2π×6 = 0.25×37.68 = 9.42"
                 },
-                { 
-                    question: "半径为 8 的圆面积是多少？(π≈3.14)", 
+                {
+                    question: "半径为 8 的圆面积是多少？(π≈3.14)",
                     answer: "200.96",
                     analysis: "面积 = πr² = 3.14 × 64 = 200.96"
                 },
-                { 
-                    question: "周长 62.8 的圆，半径是多少？(π≈3.14)", 
+                {
+                    question: "周长 62.8 的圆，半径是多少？(π≈3.14)",
                     answer: "10",
                     analysis: "C=2πr => 62.8=2×3.14×r => r=10"
                 },
-                { 
-                    question: "扇形圆心角120°，半径5，弧长是多少？(π≈3.14)", 
+                {
+                    question: "扇形圆心角120°，半径5，弧长是多少？(π≈3.14)",
                     answer: "10.47",
                     analysis: "弧长 = (120/360)×2π×5 = (1/3)×31.4 = 10.47"
                 }
             ],
             hard: [
-                { 
-                    question: "圆环外半径8，内半径3，求圆环面积。(π≈3.14)", 
+                {
+                    question: "圆环外半径8，内半径3，求圆环面积。(π≈3.14)",
                     answer: "172.7",
                     analysis: "S = π(R² - r²) = 3.14×(64-9)=3.14×55=172.7"
                 },
-                { 
-                    question: "已知扇形面积15.7，半径5，求圆心角度数(π≈3.14)", 
+                {
+                    question: "已知扇形面积15.7，半径5，求圆心角度数(π≈3.14)",
                     answer: "72",
                     analysis: "扇形面积=(n/360)×πr² => 15.7=(n/360)×78.5 => n=72"
                 },
-                { 
-                    question: "两个同心圆，外圆半径10，内圆半径6，圆环面积是多少？(π≈3.14)", 
+                {
+                    question: "两个同心圆，外圆半径10，内圆半径6，圆环面积是多少？(π≈3.14)",
                     answer: "219.8",
                     analysis: "S = π(R² - r²) = 3.14×(100-36)=3.14×64=219.8"
                 },
-                { 
-                    question: "扇形面积50.24，半径8，圆心角是多少度？(π≈3.14)", 
+                {
+                    question: "扇形面积50.24，半径8，圆心角是多少度？(π≈3.14)",
                     answer: "90",
                     analysis: "扇形面积=(n/360)×πr² => 50.24=(n/360)×200.96 => n=90"
                 },
-                { 
-                    question: "圆环外径16，内径10，圆环面积是多少？(π≈3.14)", 
+                {
+                    question: "圆环外径16，内径10，圆环面积是多少？(π≈3.14)",
                     answer: "141.3",
                     analysis: "外半径=8，内半径=5，S=π(64-25)=3.14×39=141.3"
                 },
-                { 
-                    question: "已知弧长18.84，半径6，圆心角是多少度？(π≈3.14)", 
+                {
+                    question: "已知弧长18.84，半径6，圆心角是多少度？(π≈3.14)",
                     answer: "180",
                     analysis: "弧长=(n/360)×2πr => 18.84=(n/360)×37.68 => n=180"
                 }
@@ -104,97 +102,97 @@
         },
         en: {
             basic: [
-                { 
-                    question: "If the radius of a circle is 5, what is the diameter?", 
+                {
+                    question: "If the radius of a circle is 5, what is the diameter?",
                     answer: "10",
                     analysis: "Diameter = 2 × radius, so 2 × 5 = 10."
                 },
-                { 
-                    question: "A circle has a radius of 7. What is its circumference? (π≈3.14)", 
+                {
+                    question: "A circle has a radius of 7. What is its circumference? (π≈3.14)",
                     answer: "43.96",
                     analysis: "Circumference = 2πr = 2 × 3.14 × 7 = 43.96"
                 },
-                { 
-                    question: "A circle has a diameter of 12. What is the radius?", 
+                {
+                    question: "A circle has a diameter of 12. What is the radius?",
                     answer: "6",
                     analysis: "Radius = diameter ÷ 2 = 6"
                 },
-                { 
-                    question: "What is the area of a circle with radius 3? (π≈3.14)", 
+                {
+                    question: "What is the area of a circle with radius 3? (π≈3.14)",
                     answer: "28.26",
                     analysis: "Area = πr² = 3.14 × 9 = 28.26"
                 },
-                { 
-                    question: "What is the circumference of a circle with diameter 10? (π≈3.14)", 
+                {
+                    question: "What is the circumference of a circle with diameter 10? (π≈3.14)",
                     answer: "31.4",
                     analysis: "Circumference = πd = 3.14 × 10 = 31.4"
                 },
-                { 
-                    question: "What is the diameter of a circle with radius 2?", 
+                {
+                    question: "What is the diameter of a circle with radius 2?",
                     answer: "4",
                     analysis: "Diameter = 2 × radius = 2 × 2 = 4"
                 }
             ],
             normal: [
-                { 
-                    question: "What is the area of a circle with radius 4? (π≈3.14)", 
+                {
+                    question: "What is the area of a circle with radius 4? (π≈3.14)",
                     answer: "50.24",
                     analysis: "Area = πr² = 3.14 × 16 = 50.24"
                 },
-                { 
-                    question: "A circle has a circumference of 31.4. What is its radius? (π≈3.14)", 
+                {
+                    question: "A circle has a circumference of 31.4. What is its radius? (π≈3.14)",
                     answer: "5",
                     analysis: "C=2πr => 31.4=2×3.14×r => r=5"
                 },
-                { 
-                    question: "A sector has a central angle of 90° and radius 6. What is the arc length? (π≈3.14)", 
+                {
+                    question: "A sector has a central angle of 90° and radius 6. What is the arc length? (π≈3.14)",
                     answer: "9.42",
                     analysis: "Arc length = (90/360)×2π×6 = 0.25×37.68 = 9.42"
                 },
-                { 
-                    question: "What is the area of a circle with radius 8? (π≈3.14)", 
+                {
+                    question: "What is the area of a circle with radius 8? (π≈3.14)",
                     answer: "200.96",
                     analysis: "Area = πr² = 3.14 × 64 = 200.96"
                 },
-                { 
-                    question: "A circle has a circumference of 62.8. What is its radius? (π≈3.14)", 
+                {
+                    question: "A circle has a circumference of 62.8. What is its radius? (π≈3.14)",
                     answer: "10",
                     analysis: "C=2πr => 62.8=2×3.14×r => r=10"
                 },
-                { 
-                    question: "A sector has a central angle of 120° and radius 5. What is the arc length? (π≈3.14)", 
+                {
+                    question: "A sector has a central angle of 120° and radius 5. What is the arc length? (π≈3.14)",
                     answer: "10.47",
                     analysis: "Arc length = (120/360)×2π×5 = (1/3)×31.4 = 10.47"
                 }
             ],
             hard: [
-                { 
-                    question: "A ring has an outer radius of 8 and an inner radius of 3. What is the area? (π≈3.14)", 
+                {
+                    question: "A ring has an outer radius of 8 and an inner radius of 3. What is the area? (π≈3.14)",
                     answer: "172.7",
                     analysis: "S = π(R² - r²) = 3.14×(64-9)=3.14×55=172.7"
                 },
-                { 
-                    question: "A sector has an area of 15.7 and radius 5. What is the central angle? (π≈3.14)", 
+                {
+                    question: "A sector has an area of 15.7 and radius 5. What is the central angle? (π≈3.14)",
                     answer: "72",
                     analysis: "Sector area=(n/360)×πr² => 15.7=(n/360)×78.5 => n=72"
                 },
-                { 
-                    question: "Two concentric circles have outer radius 10 and inner radius 6. What is the ring area? (π≈3.14)", 
+                {
+                    question: "Two concentric circles have outer radius 10 and inner radius 6. What is the ring area? (π≈3.14)",
                     answer: "219.8",
                     analysis: "S = π(R² - r²) = 3.14×(100-36)=3.14×64=219.8"
                 },
-                { 
-                    question: "A sector has an area of 50.24 and radius 8. What is the central angle? (π≈3.14)", 
+                {
+                    question: "A sector has an area of 50.24 and radius 8. What is the central angle? (π≈3.14)",
                     answer: "90",
                     analysis: "Sector area=(n/360)×πr² => 50.24=(n/360)×200.96 => n=90"
                 },
-                { 
-                    question: "A ring has outer diameter 16 and inner diameter 10. What is the area? (π≈3.14)", 
+                {
+                    question: "A ring has outer diameter 16 and inner diameter 10. What is the area? (π≈3.14)",
                     answer: "141.3",
                     analysis: "Outer radius=8, inner radius=5, S=π(64-25)=3.14×39=141.3"
                 },
-                { 
-                    question: "An arc has length 18.84 and radius 6. What is the central angle? (π≈3.14)", 
+                {
+                    question: "An arc has length 18.84 and radius 6. What is the central angle? (π≈3.14)",
                     answer: "180",
                     analysis: "Arc length=(n/360)×2πr => 18.84=(n/360)×37.68 => n=180"
                 }
@@ -202,297 +200,565 @@
         }
     };
 
-    // DOM 元素
+    const translations = {
+        en: {
+            'btn-lang': 'EN / 中',
+            'btn-contrast': 'Contrast',
+            'logo-text': 'CircleMaster',
+            'nav-home': 'Home',
+            'nav-game': 'Game',
+            'nav-quiz': 'Quiz',
+            'bc-home': 'Home',
+            'bc-current': 'Quiz',
+            'page-title': 'CircleMaster - Interactive Geometry Learning',
+            'theme-dark': 'Dark Mode',
+            'theme-light': 'Light Mode',
+            'audio-on': 'Sound On',
+            'audio-off': 'Sound Off',
+            'nav-toggle-label': 'Menu',
+            'modal-close': 'OK',
+            'footer-copy': '© 2026 25/26_EBU5315_G19. All rights reserved.',
+            'footer-data': 'Data Policy',
+            'footer-access': 'Accessibility',
+            'footer-contact': 'Contact Us',
+            'level-legend': 'Level',
+            'level-basic': 'Basic',
+            'level-normal': 'Normal',
+            'level-hard': 'Hard',
+            'btn-next': 'Next',
+            'btn-analysis': 'Analysis',
+            'btn-feedback': 'Feedback',
+            'answer-placeholder': 'Enter your answer',
+            'answer-aria': 'Enter your answer',
+            'quiz-empty': '[ Quiz Area ]',
+            'quiz-no-questions': 'No questions available right now.',
+            'feedback-no-question': 'No question available for feedback.',
+            'feedback-empty': 'Please enter an answer first, then check feedback.',
+            'feedback-correct': 'Correct! Keep it up.',
+            'feedback-wrong': 'Incorrect. Correct answer: {answer}',
+            'analysis-text': 'Analysis: {analysis}',
+            'chat-reply-contact': 'You can reach the team at 2024213571@bupt.cn.',
+            'chat-reply-default': 'Use the shared footer links for policies, accessibility details, and contact information.'
+        },
+        zh: {
+            'btn-lang': '中 / EN',
+            'btn-contrast': '对比度',
+            'logo-text': '圆几何大师',
+            'nav-home': '首页',
+            'nav-game': '游戏',
+            'nav-quiz': '测验',
+            'bc-home': '首页',
+            'bc-current': '测验',
+            'page-title': 'CircleMaster - 圆几何互动学习',
+            'theme-dark': '黑夜模式',
+            'theme-light': '明亮模式',
+            'audio-on': '声音开启',
+            'audio-off': '声音关闭',
+            'nav-toggle-label': '菜单',
+            'modal-close': '确定',
+            'footer-copy': '© 2026 25/26_EBU5315_G19. 保留所有权利。',
+            'footer-data': '数据政策',
+            'footer-access': '无障碍说明',
+            'footer-contact': '联系我们',
+            'level-legend': '难度',
+            'level-basic': '基础',
+            'level-normal': '进阶',
+            'level-hard': '挑战',
+            'btn-next': '下一题',
+            'btn-analysis': '解析',
+            'btn-feedback': '反馈',
+            'answer-placeholder': '请输入你的答案',
+            'answer-aria': '请输入你的答案',
+            'quiz-empty': '[ 测验区 ]',
+            'quiz-no-questions': '当前暂无题目。',
+            'feedback-no-question': '当前没有可反馈的题目。',
+            'feedback-empty': '请先输入答案，然后再查看反馈。',
+            'feedback-correct': '你答对了，继续保持。',
+            'feedback-wrong': '答案不对，正确答案是：{answer}',
+            'analysis-text': '解析：{analysis}',
+            'chat-reply-contact': '你可以通过 2024213571@bupt.cn 联系团队。',
+            'chat-reply-default': '你可以通过页脚的共享链接查看数据政策、无障碍说明和联系方式。'
+        }
+    };
+
+    const state = {
+        currentLang: 'en',
+        currentLevel: 'basic',
+        currentQuestions: [],
+        currentIndex: 0,
+        currentQuestionObj: null,
+        soundEnabled: true,
+        currentFontSize: 16,
+        currentFooterModalType: null
+    };
+
     const canvasDiv = document.getElementById('circle-canvas');
-    const questionPara = canvasDiv.querySelector('p') || document.createElement('p');
-    const answerInput = canvasDiv.querySelector('input');
+    const questionPara = canvasDiv ? (canvasDiv.querySelector('p') || document.createElement('p')) : null;
+    const answerInput = document.getElementById('answer-input');
     const nextBtn = document.getElementById('next-btn');
     const analysisBtn = document.getElementById('analysis-btn');
     const feedbackBtn = document.getElementById('feedback-btn');
-    const levelRadios = document.querySelectorAll('input[name="Level"]');
+    const levelRadios = Array.from(document.querySelectorAll('input[name="Level"]'));
     const themeBtn = document.getElementById('theme-btn');
     const audioBtn = document.getElementById('audio-btn');
+    const privacyModal = document.getElementById('privacy-modal');
+    const privacyBody = document.getElementById('privacy-body');
 
-    // 状态变量
-    let currentLang = 'zh'; // zh / en
-    let currentLevel = 'basic';       // basic / normal / hard
-    let currentQuestions = [];
-    let currentIndex = 0;
-    let currentQuestionObj = null;
-    let lastAnswerCorrect = false;
-    let soundEnabled = true;          // 默认开启音效
-    let isDarkMode = false;           // 默认亮模式
-    let fontSizeLevel = 0;            // 字体大小级别: -2 到 2
-
-    // 初始化: 确保画布里段落存在
-    if (!canvasDiv.querySelector('p')) {
-        const p = document.createElement('p');
-        p.textContent = '[ Quiz Area ]';
-        canvasDiv.insertBefore(p, answerInput);
+    if (canvasDiv && questionPara && !questionPara.parentNode) {
+        canvasDiv.insertBefore(questionPara, answerInput || null);
     }
 
-    // 加载对应等级题库
-    function loadQuestionsByLevel(level) {
-        if (!questionBank[currentLang]) return [];
-        if (level === 'basic') return [...questionBank[currentLang].basic];
-        if (level === 'normal') return [...questionBank[currentLang].normal];
-        if (level === 'hard') return [...questionBank[currentLang].hard];
-        return [...questionBank[currentLang].basic];
-    }
-
-    // 更新界面显示题目
-    function displayQuestion(qObj) {
-        if (!qObj) return;
-        const displayP = canvasDiv.querySelector('p');
-        displayP.textContent = qObj.question;
-        answerInput.value = '';
-        // 移除之前的反馈信息 (如果有动态插入的反馈元素)
-        const oldFeedback = canvasDiv.querySelector('.answer-feedback');
-        if (oldFeedback) oldFeedback.remove();
-        const oldAnalysis = canvasDiv.querySelector('.analysis-text');
-        if (oldAnalysis) oldAnalysis.remove();
-    }
-
-    // 刷新当前题目 (根据level和index)
-    function refreshQuestion() {
-        if (!currentQuestions.length) {
-            currentQuestions = loadQuestionsByLevel(currentLevel);
-            currentIndex = 0;
-        }
-        if (currentQuestions.length > 0) {
-            currentQuestionObj = currentQuestions[currentIndex % currentQuestions.length];
-            displayQuestion(currentQuestionObj);
-        } else {
-            canvasDiv.querySelector('p').textContent = '暂无题目，请选择题库';
-        }
-    }
-
-    // 切换等级
-    function setLevel(level) {
-        currentLevel = level;
-        currentQuestions = loadQuestionsByLevel(level);
-        currentIndex = 0;
-        refreshQuestion();
-        // 播放切换音效（可选）
-        playSound('switch');
-    }
-
-    // 等级监听
-    levelRadios.forEach(radio => {
-        radio.addEventListener('change', (e) => {
-            if (e.target.checked) {
-                const levelKey = e.target.value || 'basic';
-                setLevel(levelKey);
-            }
+    function t(key, vars = {}) {
+        const table = translations[state.currentLang] || translations.en;
+        let output = table[key] || translations.en[key] || key;
+        Object.keys(vars).forEach((name) => {
+            output = output.replace(`{${name}}`, vars[name]);
         });
-    });
-
-    // 默认选中Basic (若没有checked属性)
-    const defaultRadio = Array.from(levelRadios).find(r => r.parentElement?.innerText.includes('Basic') || r.parentElement?.innerText.includes('基础')) || levelRadios[0];
-    if (defaultRadio) defaultRadio.checked = true;
-    setLevel('basic');
-
-    // 主题切换函数
-    window.toggleTheme = function() {
-        isDarkMode = !isDarkMode;
-        document.body.classList.toggle('dark-mode', isDarkMode);
-        updateUILanguage(); // 更新所有界面文字，包括按钮
-    };
-
-    // 字体大小调整函数
-    window.adjustFontSize = function(delta) {
-        fontSizeLevel += delta;
-        fontSizeLevel = Math.max(-2, Math.min(2, fontSizeLevel)); // 限制在 -2 到 2
-        const baseSize = 16; // 基准字体大小
-        const newSize = baseSize + fontSizeLevel * 2; // 每次增减 2px
-        document.body.style.fontSize = newSize + 'px';
-    };
-
-    // 音效切换函数
-    window.toggleSound = function() {
-        soundEnabled = !soundEnabled;
-        updateUILanguage(); // 更新按钮文字
-    };
-
-    // Feedback 显示函数
-    function showFeedback() {
-        let feedbackDiv = canvasDiv.querySelector('.answer-feedback');
-        if (!feedbackDiv) {
-            feedbackDiv = document.createElement('div');
-            feedbackDiv.className = 'answer-feedback';
-            canvasDiv.appendChild(feedbackDiv);
-        }
-
-        if (!currentQuestionObj) {
-            feedbackDiv.textContent = currentLang === 'zh' ? '当前没有题目可反馈。' : 'No question available for feedback.';
-            feedbackDiv.style.color = 'var(--warning-color)';
-            return;
-        }
-
-        const userAnswer = answerInput.value.trim();
-        if (!userAnswer) {
-            feedbackDiv.textContent = currentLang === 'zh' ? '请先输入答案，然后再查看反馈。' : 'Please enter an answer first, then check feedback.';
-            feedbackDiv.style.color = 'var(--warning-color)';
-            return;
-        }
-
-        const correctAnswer = currentQuestionObj.answer;
-        const isCorrect = userAnswer.toLowerCase() === correctAnswer.toLowerCase();
-        if (isCorrect) {
-            feedbackDiv.textContent = currentLang === 'zh' ? '你答对了！继续保持。' : 'Correct! Keep it up.';
-            feedbackDiv.style.color = 'var(--success-color)';
-        } else {
-            feedbackDiv.textContent = currentLang === 'zh' ? `答案不对，正确答案是：${correctAnswer}` : `Incorrect. Correct answer: ${correctAnswer}`;
-            feedbackDiv.style.color = 'var(--error-color)';
-        }
-        lastAnswerCorrect = isCorrect;
+        return output;
     }
 
-    // 按钮事件监听
-    themeBtn.addEventListener('click', toggleTheme);
-    audioBtn.addEventListener('click', toggleSound);
-    nextBtn.addEventListener('click', nextQuestion);
-    analysisBtn.addEventListener('click', showAnalysis);
-    feedbackBtn.addEventListener('click', showFeedback);
+    function updateThemeButton() {
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        const themeIcon = document.getElementById('theme-icon');
+        const themeLabel = document.getElementById('theme-label');
 
-    // 初始化界面文字
-    updateUILanguage();
-
-    // 语言切换函数
-    window.changeLanguage = function() {
-        currentLang = (currentLang === 'zh') ? 'en' : 'zh';
-        // 切换题库
-        currentQuestions = loadQuestionsByLevel(currentLevel);
-        currentIndex = 0;
-        refreshQuestion();
-        // 切换界面文字
-        updateUILanguage();
-    };
-
-    // 更新界面文字
-    function updateUILanguage() {
-        // 题目输入框 placeholder
-        answerInput.placeholder = currentLang === 'zh' ? '请输入你的答案' : 'Enter your answer';
-        // Next/Analysis/Feedback 按钮
-        nextBtn.textContent = currentLang === 'zh' ? '下一题' : 'Next';
-        analysisBtn.textContent = currentLang === 'zh' ? '解析' : 'Analysis';
-        feedbackBtn.textContent = currentLang === 'zh' ? '反馈' : 'Feedback';
-        // Level 单选框
-        const levelLabels = document.querySelectorAll('label[for^="level-"]');
-        const levelTexts = currentLang === 'zh' ? ['基础', '进阶', '挑战'] : ['Basic', 'Normal', 'Hard'];
-        levelLabels.forEach((label, i) => { label.textContent = levelTexts[i]; });
-        // Level 标题
-        const legend = document.querySelector('.level-fieldset legend');
-        if (legend) legend.textContent = currentLang === 'zh' ? '难度' : 'Level';
-        // Quiz Area
-        const quizAreaP = canvasDiv.querySelector('p');
-        if (quizAreaP && (!currentQuestionObj)) quizAreaP.textContent = currentLang === 'zh' ? '[ 测验区 ]' : '[ Quiz Area ]';
-        // 面包屑
-        const breadcrumb = document.querySelector('.breadcrumb');
-        if (breadcrumb) {
-            breadcrumb.innerHTML = currentLang === 'zh' ? '<a href="index.html">首页 (Home)</a> &nbsp;>&nbsp; <span>测验</span>' : '<a href="index.html">Home (首页)</a> &nbsp;>&nbsp; <span>Quiz</span>';
+        if (themeIcon) {
+            themeIcon.textContent = isDark ? '☀️' : '🌙';
         }
-        // 页脚
-        const footerLinks = document.querySelectorAll('.footer-links a');
-        if (footerLinks.length === 3) {
-            footerLinks[0].textContent = currentLang === 'zh' ? '数据隐私政策' : 'Data Policy';
-            footerLinks[1].textContent = currentLang === 'zh' ? '无障碍声明' : 'Accessibility';
-            footerLinks[2].textContent = currentLang === 'zh' ? '联系我们' : 'Contact Us';
+        if (themeLabel) {
+            themeLabel.textContent = isDark ? t('theme-light') : t('theme-dark');
         }
-        // 更新按钮文字
-        themeBtn.textContent = isDarkMode ? (currentLang === 'zh' ? '☀️ 亮模式' : '☀️ Light Mode') : (currentLang === 'zh' ? '🌙 暗模式' : '🌙 Dark Mode');
-        audioBtn.textContent = soundEnabled ? (currentLang === 'zh' ? '🔊 音效' : '🔊 Sound') : (currentLang === 'zh' ? '🔇 静音' : '🔇 Muted');
     }
 
-    // 答案检查与反馈
-    function checkAnswer() {
-        if (!currentQuestionObj) return false;
-        const userAnswer = answerInput.value.trim();
-        const correctAnswer = currentQuestionObj.answer;
-        // 简单比较 (忽略大小写与空格)
-        const isCorrect = userAnswer.toLowerCase() === correctAnswer.toLowerCase();
-        
-        // 显示即时反馈
-        let feedbackDiv = canvasDiv.querySelector('.answer-feedback');
-        if (!feedbackDiv) {
-            feedbackDiv = document.createElement('div');
-            feedbackDiv.className = 'answer-feedback';
-            canvasDiv.appendChild(feedbackDiv);
+    function updateAudioButton() {
+        const audioIcon = document.getElementById('audio-icon');
+        const audioLabel = document.getElementById('audio-label');
+
+        if (audioIcon) {
+            audioIcon.textContent = state.soundEnabled ? '🔊' : '🔇';
         }
-        if (isCorrect) {
-            feedbackDiv.textContent = '✅ 正确！很棒！';
-            feedbackDiv.style.color = 'var(--success-color)';
-            playSound('correct');
-        } else {
-            feedbackDiv.textContent = `❌ 答案错误，再试试看 (正确: ${correctAnswer})`;
-            feedbackDiv.style.color = 'var(--error-color)';
-            playSound('wrong');
+        if (audioLabel) {
+            audioLabel.textContent = state.soundEnabled ? t('audio-on') : t('audio-off');
         }
-        lastAnswerCorrect = isCorrect;
-        return isCorrect;
     }
 
-    // 显示解析
-    function showAnalysis() {
-        if (!currentQuestionObj) return;
-        // 先检查答案, 但也可以不依赖检查
-        let analysisDiv = canvasDiv.querySelector('.analysis-text');
-        if (!analysisDiv) {
-            analysisDiv = document.createElement('div');
-            analysisDiv.className = 'analysis-text';
-            canvasDiv.appendChild(analysisDiv);
-        }
-        analysisDiv.textContent = `📘 解析: ${currentQuestionObj.analysis}`;
+    function setNavOpen(isOpen) {
+        const navToggle = document.querySelector('[data-nav-toggle]');
+        const siteNav = document.querySelector('[data-site-nav]');
+        if (!navToggle || !siteNav) return;
+
+        siteNav.classList.toggle('is-open', isOpen);
+        navToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
     }
 
-    // 下一题
-    function nextQuestion() {
-        if (!currentQuestions.length) {
-            setLevel(currentLevel);
-            return;
+    function syncBodyLock() {
+        document.body.style.overflow = privacyModal && !privacyModal.hidden ? 'hidden' : '';
+    }
+
+    function feedbackColor(type) {
+        if (type === 'success') return '#247245';
+        if (type === 'error') return '#a53a2f';
+        return 'var(--text-color)';
+    }
+
+    function removeDynamicMessages() {
+        if (!canvasDiv) return;
+        const feedback = canvasDiv.querySelector('.answer-feedback');
+        const analysis = canvasDiv.querySelector('.analysis-text');
+        if (feedback) feedback.remove();
+        if (analysis) analysis.remove();
+    }
+
+    function ensureFeedbackNode() {
+        if (!canvasDiv) return null;
+        let feedback = canvasDiv.querySelector('.answer-feedback');
+        if (!feedback) {
+            feedback = document.createElement('div');
+            feedback.className = 'answer-feedback';
+            canvasDiv.appendChild(feedback);
         }
-        // 可选：先检查当前答案？但为了流畅，直接下一题；也可以自动检查一下。
-        if (answerInput.value.trim() !== '') {
-            checkAnswer();   // 显示反馈但不阻止
+        return feedback;
+    }
+
+    function ensureAnalysisNode() {
+        if (!canvasDiv) return null;
+        let analysis = canvasDiv.querySelector('.analysis-text');
+        if (!analysis) {
+            analysis = document.createElement('div');
+            analysis.className = 'analysis-text';
+            canvasDiv.appendChild(analysis);
         }
-        // 移动到下一题
-        currentIndex = (currentIndex + 1) % currentQuestions.length;
-        currentQuestionObj = currentQuestions[currentIndex];
-        displayQuestion(currentQuestionObj);
+        return analysis;
+    }
+
+    function loadQuestionsByLevel(level) {
+        const bank = questionBank[state.currentLang] || questionBank.en;
+        return [...(bank[level] || bank.basic)];
+    }
+
+    function displayQuestion(questionObject) {
+        if (!questionPara) return;
+
+        questionPara.textContent = questionObject ? questionObject.question : t('quiz-no-questions');
+        if (answerInput) {
+            answerInput.value = '';
+        }
+        removeDynamicMessages();
+    }
+
+    function syncQuestions(resetIndex) {
+        state.currentQuestions = loadQuestionsByLevel(state.currentLevel);
+        if (resetIndex) {
+            state.currentIndex = 0;
+        }
+        if (state.currentIndex >= state.currentQuestions.length) {
+            state.currentIndex = 0;
+        }
+        state.currentQuestionObj = state.currentQuestions[state.currentIndex] || null;
+        displayQuestion(state.currentQuestionObj);
+    }
+
+    function setLevel(level) {
+        state.currentLevel = level;
+        syncQuestions(true);
         playSound('switch');
     }
 
-    // 简单音效 (使用Web Audio或Audio)
+    function normalizedAnswer(value) {
+        return String(value || '').trim().toLowerCase();
+    }
+
+    function isCurrentAnswerCorrect() {
+        if (!state.currentQuestionObj || !answerInput) return false;
+        return normalizedAnswer(answerInput.value) === normalizedAnswer(state.currentQuestionObj.answer);
+    }
+
+    function showFeedback() {
+        const feedback = ensureFeedbackNode();
+        if (!feedback) return;
+
+        if (!state.currentQuestionObj) {
+            feedback.textContent = t('feedback-no-question');
+            feedback.style.color = feedbackColor('error');
+            return;
+        }
+
+        const userAnswer = answerInput ? answerInput.value.trim() : '';
+        if (!userAnswer) {
+            feedback.textContent = t('feedback-empty');
+            feedback.style.color = feedbackColor('error');
+            return;
+        }
+
+        if (isCurrentAnswerCorrect()) {
+            feedback.textContent = t('feedback-correct');
+            feedback.style.color = feedbackColor('success');
+            playSound('correct');
+            return;
+        }
+
+        feedback.textContent = t('feedback-wrong', { answer: state.currentQuestionObj.answer });
+        feedback.style.color = feedbackColor('error');
+        playSound('wrong');
+    }
+
+    function showAnalysis() {
+        const analysis = ensureAnalysisNode();
+        if (!analysis || !state.currentQuestionObj) return;
+        analysis.textContent = t('analysis-text', { analysis: state.currentQuestionObj.analysis });
+    }
+
+    function nextQuestion() {
+        if (!state.currentQuestions.length) {
+            syncQuestions(true);
+            return;
+        }
+
+        if (answerInput && answerInput.value.trim() !== '') {
+            playSound(isCurrentAnswerCorrect() ? 'correct' : 'wrong');
+        } else {
+            playSound('switch');
+        }
+
+        state.currentIndex = (state.currentIndex + 1) % state.currentQuestions.length;
+        state.currentQuestionObj = state.currentQuestions[state.currentIndex] || null;
+        displayQuestion(state.currentQuestionObj);
+    }
+
     function playSound(type) {
-        if (!soundEnabled) return;
+        if (!state.soundEnabled) return;
+
         try {
-            const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-            if (audioCtx.state === 'suspended') {
-                audioCtx.resume();
-            }
-            const osc = audioCtx.createOscillator();
-            const gain = audioCtx.createGain();
-            osc.connect(gain);
-            gain.connect(audioCtx.destination);
-            let frequency = 440; // 默认 A4
-            let duration = 0.2;
+            const AudioContextCtor = window.AudioContext || window['webkitAudioContext'];
+            if (!AudioContextCtor) return;
+
+            const audioContext = new AudioContextCtor();
+            const oscillator = audioContext.createOscillator();
+            const gain = audioContext.createGain();
+            oscillator.connect(gain);
+            gain.connect(audioContext.destination);
+
+            let frequency = 330;
+            let duration = 0.12;
+
             if (type === 'correct') {
-                frequency = 523; // C5
-                duration = 0.3;
+                frequency = 523;
+                duration = 0.28;
             } else if (type === 'wrong') {
-                frequency = 220; // A3
-                duration = 0.5;
-            } else if (type === 'switch') {
-                frequency = 330; // E4
-                duration = 0.1;
+                frequency = 220;
+                duration = 0.4;
             }
-            osc.frequency.setValueAtTime(frequency, audioCtx.currentTime);
-            gain.gain.setValueAtTime(0.1, audioCtx.currentTime);
-            osc.start();
-            osc.stop(audioCtx.currentTime + duration);
-        } catch (e) {
+
+            oscillator.frequency.setValueAtTime(frequency, audioContext.currentTime);
+            gain.gain.setValueAtTime(0.08, audioContext.currentTime);
+            oscillator.start();
+            oscillator.stop(audioContext.currentTime + duration);
+        } catch (error) {
             console.log('Audio not supported');
         }
     }
 
+    function footerModalContent(type) {
+        if (state.currentLang === 'zh') {
+            if (type === 'data') {
+                return `
+                    <h2>数据政策</h2>
+                    <p>CircleMaster 仅用于教学演示。我们承诺以透明、最小化的方式处理站点偏好和交互内容。</p>
+                    <ul>
+                        <li><strong>实时处理：</strong> 页面内 AI 提示和交互内容仅在当前浏览器会话中使用。</li>
+                        <li><strong>个人信息：</strong> 我们不会在站点中主动收集、出售或共享你的个人信息。</li>
+                        <li><strong>联系方式：</strong> 如需反馈，请发送邮件至 2024213571@bupt.cn。</li>
+                    </ul>
+                    <div class="preference-note"><strong>偏好说明：</strong> 主题、字体和无障碍设置由浏览器当前页面即时应用。</div>
+                `;
+            }
+            if (type === 'access') {
+                return `
+                    <h2>无障碍说明</h2>
+                    <p>我们希望 Home、Game、Quiz 三页都提供一致且可理解的学习体验。</p>
+                    <ul>
+                        <li><strong>视觉支持：</strong> 支持黑夜模式、高对比度和字体缩放。</li>
+                        <li><strong>结构一致：</strong> 统一导航、面包屑和页脚，降低跨页切换成本。</li>
+                        <li><strong>持续改进：</strong> 如发现可读性或操作问题，欢迎联系团队反馈。</li>
+                    </ul>
+                `;
+            }
+            return `
+                <h2>联系我们</h2>
+                <p>如果你对课程内容、设计实现或无障碍细节有建议，欢迎联系我们。</p>
+                <ul>
+                    <li><strong>项目反馈：</strong> 可通过仓库 Issue 或邮件提交问题。</li>
+                    <li><strong>响应方式：</strong> 我们会根据课程项目节奏尽快回复。</li>
+                </ul>
+            `;
+        }
+
+        if (type === 'data') {
+            return `
+                <h2>Data Policy</h2>
+                <p>CircleMaster is an educational prototype. We keep site messaging and preference handling simple and transparent.</p>
+                <ul>
+                    <li><strong>Session-first behaviour:</strong> AI hints and page interactions stay within the current browser session.</li>
+                    <li><strong>Personal data:</strong> We do not intentionally collect, sell, or share personal user data through this site.</li>
+                    <li><strong>Contact:</strong> Reach the team at 2024213571@bupt.cn for questions or concerns.</li>
+                </ul>
+                <div class="preference-note"><strong>Preference note:</strong> Theme, font size, and accessibility controls apply directly in the browser for the current page.</div>
+            `;
+        }
+        if (type === 'access') {
+            return `
+                <h2>Accessibility Statement</h2>
+                <p>We aim to keep Home, Game, and Quiz visually consistent and easier to navigate for all learners.</p>
+                <ul>
+                    <li><strong>Visual support:</strong> Dark mode, high contrast, and font scaling are available from the shared toolbar.</li>
+                    <li><strong>Consistent structure:</strong> Navigation, breadcrumbs, and footer behaviour are aligned across pages.</li>
+                    <li><strong>Feedback welcome:</strong> Please contact the team if a control is unclear or difficult to use.</li>
+                </ul>
+            `;
+        }
+        return `
+            <h2>Contact Us</h2>
+            <p>If you have feedback about the content, design, or accessibility details, please get in touch.</p>
+            <ul>
+                <li><strong>Project feedback:</strong> You can also raise an issue in the project repository.</li>
+                <li><strong>Response style:</strong> We will reply as quickly as the course project schedule allows.</li>
+            </ul>
+        `;
+    }
+
+    function openFooterModal(type) {
+        if (!privacyModal || !privacyBody) return;
+
+        state.currentFooterModalType = type;
+        privacyBody.innerHTML = footerModalContent(type);
+        privacyModal.hidden = false;
+        setNavOpen(false);
+        syncBodyLock();
+    }
+
+    function togglePrivacyModal(show) {
+        if (!privacyModal) return;
+
+        privacyModal.hidden = !show;
+        if (!show) {
+            state.currentFooterModalType = null;
+        }
+        syncBodyLock();
+    }
+
+    function applyStaticTranslations() {
+        document.documentElement.lang = state.currentLang;
+        document.title = t('page-title');
+
+        document.querySelectorAll('[data-i18n]').forEach((node) => {
+            const key = node.getAttribute('data-i18n');
+            node.textContent = t(key);
+        });
+
+        const navToggleLabel = document.querySelector('[data-nav-toggle-label]');
+        if (navToggleLabel) {
+            navToggleLabel.textContent = t('nav-toggle-label');
+        }
+
+        const privacyCloseButton = document.querySelector('#privacy-modal .modal-close-btn');
+        if (privacyCloseButton) {
+            privacyCloseButton.textContent = t('modal-close');
+        }
+
+        const levelLegend = document.querySelector('.level-fieldset legend');
+        if (levelLegend) {
+            levelLegend.textContent = t('level-legend');
+        }
+
+        const levelLabelMap = {
+            'level-basic': 'level-basic',
+            'level-normal': 'level-normal',
+            'level-hard': 'level-hard'
+        };
+        Object.keys(levelLabelMap).forEach((id) => {
+            const label = document.querySelector(`label[for="${id}"]`);
+            if (label) {
+                label.textContent = t(levelLabelMap[id]);
+            }
+        });
+
+        if (answerInput) {
+            answerInput.placeholder = t('answer-placeholder');
+            answerInput.setAttribute('aria-label', t('answer-aria'));
+        }
+
+        if (nextBtn) nextBtn.textContent = t('btn-next');
+        if (analysisBtn) analysisBtn.textContent = t('btn-analysis');
+        if (feedbackBtn) feedbackBtn.textContent = t('btn-feedback');
+
+        updateThemeButton();
+        updateAudioButton();
+
+        if (state.currentFooterModalType && privacyModal && !privacyModal.hidden && privacyBody) {
+            privacyBody.innerHTML = footerModalContent(state.currentFooterModalType);
+        }
+    }
+
+    function changeLanguage() {
+        state.currentLang = state.currentLang === 'en' ? 'zh' : 'en';
+        applyStaticTranslations();
+        syncQuestions(false);
+    }
+
+    function toggleTheme() {
+        const currentTheme = document.documentElement.getAttribute('data-theme');
+        document.documentElement.setAttribute('data-theme', currentTheme === 'dark' ? 'light' : 'dark');
+        updateThemeButton();
+    }
+
+    function toggleContrast() {
+        const isHighContrast = document.documentElement.getAttribute('data-a11y') === 'high-contrast';
+        if (isHighContrast) {
+            document.documentElement.removeAttribute('data-a11y');
+        } else {
+            document.documentElement.setAttribute('data-a11y', 'high-contrast');
+        }
+    }
+
+    function adjustFontSize(delta) {
+        state.currentFontSize = Math.min(Math.max(state.currentFontSize + (delta * 2), 12), 26);
+        document.documentElement.style.setProperty('--font-size-base', `${state.currentFontSize}px`);
+    }
+
+    function toggleSound() {
+        state.soundEnabled = !state.soundEnabled;
+        updateAudioButton();
+    }
+
+    function setupNavToggle() {
+        const navToggle = document.querySelector('[data-nav-toggle]');
+        const siteNav = document.querySelector('[data-site-nav]');
+        if (!navToggle || !siteNav) return;
+
+        navToggle.addEventListener('click', () => {
+            const isOpen = !siteNav.classList.contains('is-open');
+            setNavOpen(isOpen);
+        });
+
+        siteNav.querySelectorAll('a').forEach((link) => {
+            link.addEventListener('click', () => setNavOpen(false));
+        });
+
+        window.addEventListener('resize', () => {
+            if (window.innerWidth > 760) {
+                setNavOpen(false);
+            }
+        });
+    }
+
+    function setupLevelControls() {
+        levelRadios.forEach((radio) => {
+            radio.addEventListener('change', (event) => {
+                if (event.target.checked) {
+                    setLevel(event.target.value || 'basic');
+                }
+            });
+        });
+
+        const basicRadio = document.getElementById('level-basic');
+        if (basicRadio) {
+            basicRadio.checked = true;
+        }
+    }
+
+    if (themeBtn) {
+        themeBtn.addEventListener('click', toggleTheme);
+    }
+
+    if (audioBtn) {
+        audioBtn.addEventListener('click', toggleSound);
+    }
+
+    if (nextBtn) {
+        nextBtn.addEventListener('click', nextQuestion);
+    }
+
+    if (analysisBtn) {
+        analysisBtn.addEventListener('click', showAnalysis);
+    }
+
+    if (feedbackBtn) {
+        feedbackBtn.addEventListener('click', showFeedback);
+    }
+
+    setupLevelControls();
+    setupNavToggle();
+    if (privacyModal) {
+        privacyModal.hidden = true;
+    }
+    syncBodyLock();
+    state.currentFontSize = parseInt(window.getComputedStyle(document.documentElement).getPropertyValue('--font-size-base'), 10) || 16;
+    applyStaticTranslations();
+    syncQuestions(true);
+
+    window.changeLanguage = changeLanguage;
+    window.toggleContrast = toggleContrast;
+    window.adjustFontSize = adjustFontSize;
+    window.openFooterModal = openFooterModal;
+    window.togglePrivacyModal = togglePrivacyModal;
 })();

--- a/quiz.html
+++ b/quiz.html
@@ -4,35 +4,49 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CircleMaster - Interactive Geometry Learning</title>
+    <link rel="stylesheet" href="css/global.css">
     <link rel="stylesheet" href="css/quiz.css">
 </head>
 <body>
     <div id="accessibility-bar">
         <div class="container">
-            <button onclick="changeLanguage()">EN / 中</button>
-            <button onclick="adjustFontSize(1)">A+</button>
-            <button onclick="adjustFontSize(-1)">A-</button>
-            <button id="theme-btn">🌙 Dark Mode</button>
-            <button id="audio-btn">🔊 Sound</button>
+            <button type="button" onclick="changeLanguage()" data-i18n="btn-lang">EN / 中</button>
+            <button type="button" onclick="toggleContrast()" data-i18n="btn-contrast">Contrast</button>
+            <button type="button" onclick="adjustFontSize(1)">A+</button>
+            <button type="button" onclick="adjustFontSize(-1)">A-</button>
+            <button id="theme-btn" type="button">
+                <span id="theme-icon">🌙</span>
+                <span id="theme-label">Dark Mode</span>
+            </button>
+            <button id="audio-btn" type="button">
+                <span id="audio-icon">🔊</span>
+                <span id="audio-label">Sound On</span>
+            </button>
         </div>
     </div>
     <header>
         <div class="container header-content">
             <a href="index.html" class="logo">
-                <span class="logo-icon">C</span> CircleMaster
+                <span class="logo-icon">C</span> <span data-i18n="logo-text">CircleMaster</span>
             </a>
-            <nav>
+            <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="quiz-site-nav" data-nav-toggle>
+                <span class="nav-toggle-icon">☰</span>
+                <span data-nav-toggle-label>Menu</span>
+            </button>
+            <nav id="quiz-site-nav" class="site-nav" data-site-nav>
                 <ul class="nav-links">
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="game.html">Game</a></li>
-                    <li><a href="quiz.html" class="active">Quiz</a></li>
+                    <li><a href="index.html" data-i18n="nav-home">Home</a></li>
+                    <li><a href="game.html" data-i18n="nav-game">Game</a></li>
+                    <li><a href="quiz.html" class="active" data-i18n="nav-quiz">Quiz</a></li>
                 </ul>
             </nav>
         </div>
     </header>
     <div class="container">
-        <nav class="breadcrumb">
-            <a href="index.html">Home (首页)</a> &nbsp;>&nbsp; <span>Quiz</span>
+        <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="index.html" data-i18n="bc-home">Home</a>
+            <span class="breadcrumb-separator" aria-hidden="true">&gt;</span>
+            <span data-i18n="bc-current">Quiz</span>
         </nav>
     </div>
     <main class="container">
@@ -66,14 +80,21 @@
     </main>
     <footer>
         <div class="container footer-content">
-            <p>© 2026 Group 33. All rights reserved.</p>
+            <p data-i18n="footer-copy">© 2026 25/26_EBU5315_G19. All rights reserved.</p>
             <div class="footer-links">
-                <a href="#">Data Policy (数据隐私政策)</a>
-                <a href="#">Accessibility (无障碍声明)</a>
-                <a href="#">Contact Us (联系我们)</a>
+                <a href="javascript:void(0)" onclick="openFooterModal('data')" data-i18n="footer-data">Data Policy</a>
+                <a href="javascript:void(0)" onclick="openFooterModal('access')" data-i18n="footer-access">Accessibility</a>
+                <a href="javascript:void(0)" onclick="openFooterModal('contact')" data-i18n="footer-contact">Contact Us</a>
             </div>
         </div>
     </footer>
+    <div id="privacy-modal" class="modal-overlay" hidden>
+        <div class="modal-content privacy-box">
+            <button type="button" class="close-modal" onclick="togglePrivacyModal(false)" aria-label="Close dialog">&times;</button>
+            <div id="privacy-body"></div>
+            <button type="button" class="modal-close-btn" onclick="togglePrivacyModal(false)">OK / 确定</button>
+        </div>
+    </div>
     <script src="js/quiz.js"></script>
 </body>
 </html>


### PR DESCRIPTION
- move shared shell styles into css/global.css so the accessibility bar, header/nav, breadcrumb, footer, modal shell, and mobile nav use one source of truth
- trim page-level CSS in home, game, and quiz so each page keeps only its own content styling while the common shell stays consistent
- align Home, Game, and Quiz HTML with the shared shell contract, including toolbar controls, nav toggle hooks, breadcrumb structure, footer links, and shared modal containers
- standardize page scripts around document.documentElement state for theme, high contrast, and font scaling, and sync the theme/audio button labels with the shared DOM structure
- unify footer modal behavior and responsive nav handling across the three pages without refactoring the main page content or business logic
- harden hidden modal startup handling so the shared overlay no longer appears on first load and blocks the page with an unclickable blurred backdrop